### PR TITLE
Allow sidebar to be zoomed over minimized sidebar

### DIFF
--- a/rails/app/assets/stylesheets/components/card.scss
+++ b/rails/app/assets/stylesheets/components/card.scss
@@ -20,8 +20,10 @@ $el-shadow: 0 1px 4px #bbb;
   }
 
   &.offCanvas {
+    max-width: 2rem;
+
     .card {
-      left: -100%;
+      display: none;
     }
     .tab {
       &:after {

--- a/rails/app/assets/stylesheets/components/card.scss
+++ b/rails/app/assets/stylesheets/components/card.scss
@@ -20,10 +20,10 @@ $el-shadow: 0 1px 4px #bbb;
   }
 
   &.offCanvas {
-    max-width: 2rem;
+    pointer-events: none;
 
     .card {
-      display: none;
+      left: -100%;
     }
     .tab {
       &:after {


### PR DESCRIPTION
Fixes #203 

Previously, it was not possible to zoom in/out over the area where the collapsed sidebar was. This mitigates the issue by reducing the width of the collapsed sidebar just to the area necessary to display the tab.

![Screenshot 2019-04-23 at 21 51 22](https://user-images.githubusercontent.com/395621/56627022-2c49f680-6612-11e9-9ffd-eb024698dbd2.png)

There's still `2rem` of area that's not zoomable, but I couldn't figure out a way to get around that without much more invasive changes. Feedback welcomed though.