### PR TITLE
[jtu+user512+alexmv] Add visual feedback to import buttons

### DIFF
--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -34,6 +34,8 @@ gem 'administrate-field-active_storage'
 gem 'webpacker', '~> 3.5'
 gem 'react-rails'
 
+gem 'font-awesome-rails', '~> 4.7'
+
 # plyr-rails gem is the integration of plyr.io javascript library for your Rails 4 and Rails 5 application.
 gem 'plyr-rails'
 

--- a/rails/Gemfile.lock
+++ b/rails/Gemfile.lock
@@ -115,6 +115,8 @@ GEM
       factory_bot (~> 5.0.0)
       railties (>= 4.2.0)
     ffi (1.9.25)
+    font-awesome-rails (4.7.0.5)
+      railties (>= 3.2, < 6.1)
     formatador (0.2.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -336,6 +338,7 @@ DEPENDENCIES
   chromedriver-helper
   devise
   factory_bot_rails
+  font-awesome-rails (~> 4.7)
   guard-rspec
   i18n-js
   jbuilder (~> 2.5)

--- a/rails/app/assets/stylesheets/admin/_admin.scss
+++ b/rails/app/assets/stylesheets/admin/_admin.scss
@@ -1,1 +1,6 @@
 @import 'story_dashboard';
+@import 'core/colors';
+
+button.btn-import:disabled {
+  background-color: $orange !important;
+}

--- a/rails/app/assets/stylesheets/admin/_admin.scss
+++ b/rails/app/assets/stylesheets/admin/_admin.scss
@@ -1,6 +1,14 @@
 @import 'story_dashboard';
 @import 'core/colors';
 
+.import-spinner {
+  display: none !important;
+}
+
 button.btn-import:disabled {
   background-color: $orange !important;
+
+  + .import-spinner {
+    display: inline-block !important;
+  }
 }

--- a/rails/app/assets/stylesheets/application.scss
+++ b/rails/app/assets/stylesheets/application.scss
@@ -2,3 +2,4 @@
 @import 'plyr';
 @import 'core/core';
 @import 'components/components';
+@import 'font-awesome';

--- a/rails/app/views/admin/application/index.html.erb
+++ b/rails/app/views/admin/application/index.html.erb
@@ -72,9 +72,13 @@ It renders the `_table` partial to display details about the resources.
     </div>
     <br>
     <div class="form-group">
-        <%= button_tag :class => "btn btn-lg btn-primary btn-import", :data => { :disable_with => 'Uploading your file...' } do %>
+        <%= button_tag :class => "btn-import",
+              :data => {
+                :disable_with => 'Uploading your file...',
+              } do %>
         <i class="fa fa-upload"></i> Import <%= page.resource_name.pluralize.capitalize %>
       <% end %>
+      <i class="fa fa-spinner fa-spin fa-lg import-spinner"></i>
     </div>
   <% end %>
 <% end %>

--- a/rails/app/views/admin/application/index.html.erb
+++ b/rails/app/views/admin/application/index.html.erb
@@ -72,7 +72,7 @@ It renders the `_table` partial to display details about the resources.
     </div>
     <br>
     <div class="form-group">
-      <%= button_tag :class => "btn btn-lg btn-primary" do %>
+        <%= button_tag :class => "btn btn-lg btn-primary btn-import", :data => { :disable_with => 'Uploading your file...' } do %>
         <i class="fa fa-upload"></i> Import <%= page.resource_name.pluralize.capitalize %>
       <% end %>
     </div>

--- a/rails/config/initializers/administrate.rb
+++ b/rails/config/initializers/administrate.rb
@@ -1,1 +1,2 @@
 Administrate::Engine.add_stylesheet('admin');
+Administrate::Engine.add_stylesheet('font-awesome');

--- a/rails/config/initializers/assets.rb
+++ b/rails/config/initializers/assets.rb
@@ -12,3 +12,4 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
 Rails.application.config.assets.precompile += %w( admin.css )
+Rails.application.config.assets.precompile += %w( font-awesome.css )


### PR DESCRIPTION
When an "Import X" button is clicked, it can take a long time and users get impatient and re-click the button multiple times.

- Disable button on-click
- Change button styling and message on-click

#### Notes
- Use terrastories colors for button color change
- Only change colors for import buttons (.btn-import)
- CSS for hovering/other attributes will override, so the !important is necessary
- The terrastories codebase does *not* use bootstrap
  - Removed css classes on `<button>` that were unused references to bootstrap classes

#### Font Awesome
Added the 'font-awesome-rails' gem.  A few notes:
* FA does *not* play nicely with engines!
  * The import button is part of the admin interface, which is created with the `administrate` gem
  * `administrate` is an engine...
  * To use FA with `administrate` or any other engine, add stylesheet reference manually in the initializer(s).
* May want to consider using `font-awesome-sass` instead of `font-awesome-rails`.
  * `font-awesome-sass` has a smaller footprint
  * `font-awesome-sass` has the latest FA version, and `font-awesome-rails` does not

Resolves https://github.com/Terrastories/terrastories/issues/223