### PR TITLE
Fix CVE-2019-5421: Devise Vulnerability

### DIFF
--- a/rails/Gemfile.lock
+++ b/rails/Gemfile.lock
@@ -69,7 +69,7 @@ GEM
     babel-transpiler (0.7.0)
       babel-source (>= 4.0, < 6)
       execjs (~> 2.0)
-    bcrypt (3.1.12)
+    bcrypt (3.1.13)
     better_errors (2.5.1)
       coderay (>= 1.0.0)
       erubi (>= 1.0.0)
@@ -100,7 +100,7 @@ GEM
     datetime_picker_rails (0.0.7)
       momentjs-rails (>= 2.8.1)
     debug_inspector (0.0.3)
-    devise (4.5.0)
+    devise (4.6.2)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 4.1.0, < 6.0)
@@ -187,7 +187,7 @@ GEM
     mysql2 (0.5.2)
     nenv (0.3.0)
     nio4r (2.3.1)
-    nokogiri (1.10.2)
+    nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
@@ -203,7 +203,7 @@ GEM
     puma (3.12.0)
     pundit (2.0.0)
       activesupport (>= 3.0.0)
-    rack (2.0.6)
+    rack (2.0.7)
     rack-proxy (0.6.5)
       rack
     rack-test (1.1.0)
@@ -242,9 +242,9 @@ GEM
       execjs
       railties (>= 3.2)
       tilt
-    responders (2.4.0)
-      actionpack (>= 4.2.0, < 5.3)
-      railties (>= 4.2.0, < 5.3)
+    responders (2.4.1)
+      actionpack (>= 4.2.0, < 6.0)
+      railties (>= 4.2.0, < 6.0)
     rgeo (1.1.1)
     rgeo-geojson (2.0.0)
       rgeo (~> 1.0)
@@ -306,8 +306,8 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.1.19)
       execjs (>= 0.3.0, < 3)
-    warden (1.2.7)
-      rack (>= 1.0)
+    warden (1.2.8)
+      rack (>= 2.0.6)
     web-console (3.7.0)
       actionview (>= 5.0)
       activemodel (>= 5.0)
@@ -367,4 +367,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.17.1
+   2.0.1

--- a/rails/Gemfile.lock
+++ b/rails/Gemfile.lock
@@ -367,4 +367,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   2.0.1
+   1.17.1


### PR DESCRIPTION
This changes updates to Devise 4.6.2.

> Details
>
> CVE-2019-5421
>
> Patched version: 4.6.0
>
> Devise ruby gem before 4.6.0 when the lockable module is used is vulnerable to a time-of-check time-of-use (TOCTOU) race condition due to `increment_failed_attempts` within the `Devise::Models::Lockable` class not being concurrency safe.

![doctor](https://media.giphy.com/media/IFYC4a626ywVy/giphy.gif)