### PR TITLE
WS-2019-0100: fstream Vulnerability

### DIFF
--- a/rails/package.json
+++ b/rails/package.json
@@ -8,6 +8,7 @@
     "@rails/webpacker": "3.5",
     "babel-jest": "^23.6.0",
     "babel-preset-react": "^6.24.1",
+    "fstream": "1.0.12",
     "prop-types": "^15.6.2",
     "react": "^16.4.2",
     "react-dom": "^16.4.2",

--- a/rails/yarn.lock
+++ b/rails/yarn.lock
@@ -3187,6 +3187,16 @@ fsevents@^1.2.3:
     nan "^2.9.2"
     node-pre-gyp "^0.10.0"
 
+fstream@1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.12.tgz#4e8ba8ee2d48be4f7d0de505455548eae5932045"
+  integrity sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==
+  dependencies:
+    graceful-fs "^4.1.2"
+    inherits "~2.0.0"
+    mkdirp ">=0.5 0"
+    rimraf "2"
+
 fstream@^1.0.0, fstream@^1.0.2:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.11.tgz#5c1fb1f117477114f0632a0eb4b71b3cb0fd3171"


### PR DESCRIPTION
This change updates fstream to v1.0.12

> Details
>
> WS-2019-0100 More information
>
> Severity moderate
> Vulnerable versions: < 1.0.12
> Patched version: 1.0.12
>
> Versions of fstream prior to 1.0.12 are vulnerable to Arbitrary File Overwrite.