### PR TITLE
[163] Update Speaker model to include birth_place and birthyear

### DIFF
--- a/rails/app/dashboards/speaker_dashboard.rb
+++ b/rails/app/dashboards/speaker_dashboard.rb
@@ -14,6 +14,8 @@ class SpeakerDashboard < Administrate::BaseDashboard
     region: Field::String,
     community: Field::String,
     stories: Field::HasMany,
+    birth_year: Field::DateTime.with_options(format: "%Y"),
+    birthplace: Field::BelongsTo.with_options(class_name: "Place"),
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
   }.freeze
@@ -40,6 +42,8 @@ class SpeakerDashboard < Administrate::BaseDashboard
     :region,
     :community,
     :stories,
+    :birth_year,
+    :birthplace,
     :created_at,
     :updated_at,
   ].freeze
@@ -52,7 +56,9 @@ class SpeakerDashboard < Administrate::BaseDashboard
     :name,
     :region,
     :community,
-    :stories
+    :stories,
+    :birth_year,
+    :birthplace,
   ].freeze
 
   # Overwrite this method to customize how speakers are displayed

--- a/rails/app/models/place.rb
+++ b/rails/app/models/place.rb
@@ -1,6 +1,7 @@
 class Place < ApplicationRecord
   require 'csv'
   has_many :points
+  has_many :speakers
 
   has_one_attached :photo
   validate :photo_format

--- a/rails/app/models/speaker.rb
+++ b/rails/app/models/speaker.rb
@@ -1,4 +1,3 @@
-require 'pry'
 # == Schema Information ==
 #
 # Table name: speakers

--- a/rails/app/models/speaker.rb
+++ b/rails/app/models/speaker.rb
@@ -1,8 +1,24 @@
+# == Schema Information ==
+#
+# Table name: speakers
+# 
+# id          ... not null primary key
+# speaker_name... string
+# birth_year  ... datetime, nil if blank
+# birthplace  ... string, classname: place
+# photo       ... string, url to attached media
+# region ------ removed
+# community --- removed
+# created_at  ... datetime, not null
+# updated_at  ... datetime, not null
+
 class Speaker < ApplicationRecord
   has_many :speaker_stories
   has_many :stories, through: :speaker_stories
+  has_one :birthplace, class_name: Place
   has_one_attached :media
 
+  # photo
   def picture_url
     if media.attached?
       Rails.application.routes.url_helpers.rails_blob_path(media, only_path: true)
@@ -13,13 +29,16 @@ class Speaker < ApplicationRecord
 
   def self.import_csv(filename)
     CSV.parse(filename, headers: true) do |row|
-      speaker = Speaker.where(name: row[0], community: row[2]).first_or_create
+      speaker = Speaker.where(
+        name: row[0], 
+        birth_year: row[1].nil? ? nil : Date.parse(row[1]), 
+        birthplace: Place.find_by(name: row[2])).first_or_create
+
       if row[3] && File.exist?(Rails.root.join('media', row[3]))
         file = File.open(Rails.root.join('media',row[3]))
         speaker.media.attach(io: file, filename: row[3])
+      
         speaker.save
-      end
     end
   end
-
 end

--- a/rails/app/models/speaker.rb
+++ b/rails/app/models/speaker.rb
@@ -47,6 +47,6 @@ class Speaker < ApplicationRecord
     if name.nil? || name.downcase == 'unknown'
       return nil
     end
-    return Place.find_or_create_by(name: name)
+    Place.find_or_create_by(name: name)
   end
 end

--- a/rails/app/models/speaker.rb
+++ b/rails/app/models/speaker.rb
@@ -1,3 +1,4 @@
+require 'pry'
 # == Schema Information ==
 #
 # Table name: speakers
@@ -5,7 +6,7 @@
 # id          ... not null primary key
 # speaker_name... string
 # birth_year  ... datetime, nil if blank
-# birthplace  ... string, classname: place
+# birthplace_id  ... integer, classname: place
 # photo       ... string, url to attached media
 # region ------ removed
 # community --- removed
@@ -13,9 +14,8 @@
 # updated_at  ... datetime, not null
 
 class Speaker < ApplicationRecord
-  has_many :speaker_stories
-  has_many :stories, through: :speaker_stories
-  has_one :birthplace, class_name: Place
+  has_many :speaker_stories, dependent: :destroy
+  belongs_to :birthplace, class_name: "Place",  optional: true
   has_one_attached :media
 
   # photo
@@ -29,16 +29,24 @@ class Speaker < ApplicationRecord
 
   def self.import_csv(filename)
     CSV.parse(filename, headers: true) do |row|
-      speaker = Speaker.where(
+      speaker = Speaker.find_or_create_by(
         name: row[0], 
-        birth_year: row[1].nil? ? nil : Date.parse(row[1]), 
-        birthplace: Place.find_by(name: row[2])).first_or_create
-
+        birth_year: row[1].nil? ? nil : Date.strptime(row[1], "%Y"), 
+        birthplace: get_birthplace(row[2])
+      )
       if row[3] && File.exist?(Rails.root.join('media', row[3]))
         file = File.open(Rails.root.join('media',row[3]))
         speaker.media.attach(io: file, filename: row[3])
       
         speaker.save
+      end
     end
+  end
+
+  def self.get_birthplace(name)
+    if name.nil? || name.downcase == 'unknown'
+      return nil
+    end
+    return Place.find_or_create_by(name: name)
   end
 end

--- a/rails/db/migrate/20190601150752_add_birth_place_and_year_to_speaker.rb
+++ b/rails/db/migrate/20190601150752_add_birth_place_and_year_to_speaker.rb
@@ -1,0 +1,6 @@
+class AddBirthPlaceAndYearToSpeaker < ActiveRecord::Migration[5.2]
+  def change
+    add_column :speakers, :birth_year, :datetime
+    add_column :speakers, :birthplace_id, :integer
+  end
+end

--- a/rails/db/migrate/20190601160029_remove_birthplace_id_and_add_place_references_to_speakers.rb
+++ b/rails/db/migrate/20190601160029_remove_birthplace_id_and_add_place_references_to_speakers.rb
@@ -1,0 +1,6 @@
+class RemoveBirthplaceIdAndAddPlaceReferencesToSpeakers < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :speakers, :birthplace_id
+    add_reference :speakers, :place
+  end
+end

--- a/rails/db/migrate/20190601162514_remove_place_reference_and_add_birthplace_reference_to_speaker.rb
+++ b/rails/db/migrate/20190601162514_remove_place_reference_and_add_birthplace_reference_to_speaker.rb
@@ -1,0 +1,6 @@
+class RemovePlaceReferenceAndAddBirthplaceReferenceToSpeaker < ActiveRecord::Migration[5.2]
+  def change
+    remove_reference :speakers, :place
+    add_reference :speakers, :birthplace
+  end
+end

--- a/rails/db/migrate/20190601184401_make_birth_place_nullable_for_speaker.rb
+++ b/rails/db/migrate/20190601184401_make_birth_place_nullable_for_speaker.rb
@@ -1,0 +1,5 @@
+class MakeBirthPlaceNullableForSpeaker < ActiveRecord::Migration[5.2]
+  def change
+    change_column :speakers, :birthplace_id, :integer, null: true
+  end
+end

--- a/rails/db/schema.rb
+++ b/rails/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_01_153747) do
+ActiveRecord::Schema.define(version: 2019_06_01_184401) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -65,6 +65,9 @@ ActiveRecord::Schema.define(version: 2019_06_01_153747) do
     t.string "community"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "birth_year"
+    t.integer "birthplace_id"
+    t.index ["birthplace_id"], name: "index_speakers_on_birthplace_id"
   end
 
   create_table "stories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/rails/spec/models/place_spec.rb
+++ b/rails/spec/models/place_spec.rb
@@ -1,7 +1,20 @@
 require 'rails_helper'
 
 RSpec.describe Place, type: :model do
-  it 'can be initialized' do
-    expect(create(:place)).to be_a(Place)
+
+  let(:place) { Place.create!(name: "Place", type_of_place: "placetype")}
+
+  describe "initialize" do
+    it 'can be initialized' do
+      expect(create(:place)).to be_a(Place)
+    end
   end
+
+  describe "attributes" do
+    it "responds to attributes name and placetype" do
+      expect(place).to have_attributes(name: "Place", type_of_place: "placetype")
+    end
+  end
+
+
 end

--- a/rails/spec/models/speaker_spec.rb
+++ b/rails/spec/models/speaker_spec.rb
@@ -1,7 +1,21 @@
 require 'rails_helper'
 
 RSpec.describe Speaker, type: :model do
-  it 'can be initialized' do
-    expect(create(:speaker)).to be_a(Speaker)
+
+  let(:place) { Place.create!(name: "Place", type_of_place: "placetype")}
+  let(:speaker) { Speaker.create!(name: 'Speaker Name', birth_year: Date.ordinal(1992), birthplace: place ) }
+    
+    describe "attributes" do
+      it "responds to name birthplace and birthyear" do
+        expect(speaker).to have_attributes(name: 'Speaker Name', birth_year: Date.ordinal(1992), birthplace: place)
+      end
+    end
+
+  describe "initialize model" do
+    it 'can be initialized' do
+      expect(create(:speaker)).to be_a(Speaker)
+    end
   end
+
+
 end


### PR DESCRIPTION
Closes #163 

Updates to the Speaker model to include new fields - birth_place (One to Many relationship with Place) and birthyear (DateTime, in format Year)

Also includes updates to the administrate dashboard so these new fields can be added and changed. 

Importer is updated to handle the new columns too. If the CSV value is `unknown` or empty, we will set a null birthplace. 