### PR TITLE
Cleaning up Dockerfiles and removing copies of node_modules directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ capybara-*.html
 *.orig
 rerun.txt
 pickle-email-*.html
+*.swp
 
 # TODO Comment out this rule if you are OK with secrets being uploaded to the repo
 config/initializers/secret_token.rb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,19 +44,11 @@ services:
       - railroad
     tty: true # Enables debugging capabilities when attached to this container.
     volumes:
-      - type: bind
-        source: ./media
-        target: /media
-      - type: bind
-        source: ./rails
-        target: /app
-      - type: bind
-        source: ./rails/nginx
-        target: /etc/nginx
-      - type: volume
-        target: /app/log
-      - type: volume
-        target: /app/tmp
+      - ./media:/media
+      - ./rails:/app
+      - ./rails/nginx:/etc/nginx
+      - /app/log
+      - /app/tmp
 
   tilebuilder:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,9 +44,19 @@ services:
       - railroad
     tty: true # Enables debugging capabilities when attached to this container.
     volumes:
-      - ./media:/media:rw
-      - ./rails:/app
-      - ./rails/nginx:/etc/nginx:rw
+      - type: bind
+        source: ./media
+        target: /media
+      - type: bind
+        source: ./rails
+        target: /app
+      - type: bind
+        source: ./rails/nginx
+        target: /etc/nginx
+      - type: volume
+        target: /app/log
+      - type: volume
+        target: /app/tmp
 
   tilebuilder:
     build:

--- a/rails/.dockerignore
+++ b/rails/.dockerignore
@@ -1,0 +1,5 @@
+Dockerfile
+log
+README.md
+tmp
+node_modules

--- a/rails/.yarnrc
+++ b/rails/.yarnrc
@@ -1,0 +1,1 @@
+--modules-folder /node_modules

--- a/rails/.yarnrc
+++ b/rails/.yarnrc
@@ -1,1 +1,1 @@
---modules-folder /node_modules
+--modules-folder ../node_modules

--- a/rails/Dockerfile
+++ b/rails/Dockerfile
@@ -1,14 +1,15 @@
 FROM ruby:2.5.1
-RUN apt-get update
-RUN apt-get install -y apt-transport-https
+RUN apt-get update \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      apt-transport-https \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
 RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
 
 RUN apt-get install -y build-essential libpq-dev nodejs yarn
-
-COPY entrypoint.sh /entrypoint.sh
-RUN chmod a+x entrypoint.sh
 
 ENV NODE_ENV=development
 ENV RAILS_ENV=development
@@ -16,13 +17,16 @@ ENV RAILS_ENV=development
 RUN mkdir /app
 WORKDIR /app
 
-COPY Gemfile Gemfile.lock package.json yarn.lock ./
+COPY Gemfile Gemfile.lock package.json yarn.lock .yarnrc ./
 RUN bundle install
 RUN yarn install
 RUN bundle exec rails new .
-RUN mv node_modules /node_modules
-RUN chmod a+r /node_modules
 RUN mv yarn.lock /yarn.lock
 
-CMD /entrypoint.sh
+COPY . .
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod a+x /entrypoint.sh
+CMD ["/entrypoint.sh"]
+HEALTHCHECK --start-period=10m --timeout=120s --interval=120s CMD curl localhost:3000/en/home || exit 1
 

--- a/rails/entrypoint.sh
+++ b/rails/entrypoint.sh
@@ -1,8 +1,10 @@
-echo "Removing existing yarn modules from host"
-rm -rf /app/node_modules /app/yarn.lock
+#!/bin/sh
 
-echo "Copying container yarn modules"
-cp -rf /node_modules /app/node_modules
+# echo "Removing existing yarn modules from host"
+# rm -rf /app/node_modules /app/yarn.lock
+# cp -rf /node_modules /app/node_modules
+
+echo "Copying container yarn lock"
 cp -rf /yarn.lock /app/yarn.lock
 
 echo "Removing artifacts from previous run"
@@ -31,4 +33,4 @@ bundle exec rails acts_as_taggable_on_engine:install:migrations
 bundle exec rails webpacker:compile
 
 echo "Starting server"
-bundle exec rails server -p 3000 -b '0.0.0.0'
+exec bundle exec rails server -p 3000 -b '0.0.0.0'

--- a/rails/entrypoint.sh
+++ b/rails/entrypoint.sh
@@ -7,6 +7,14 @@
 echo "Copying container yarn lock"
 cp -rf /yarn.lock /app/yarn.lock
 
+if [ ! -L node_modules ]; then
+  echo "Creating node_modules link in container"
+  rm -rf node_modules
+  ln -sf /node_modules node_modules
+fi
+
+# rm -rf /app/node_modules /app/yarn.lock
+
 echo "Removing artifacts from previous run"
 rm -rf /app/log/*
 rm -rf /app/tmp/*

--- a/rails/package.json
+++ b/rails/package.json
@@ -36,7 +36,7 @@
       "!**/spec/javascript/coverage/**"
     ],
     "moduleDirectories": [
-      "node_modules"
+      "../node_modules"
     ]
   }
 }

--- a/script/start
+++ b/script/start
@@ -1,2 +1,7 @@
-#!/bin/bash
+#!/bin/sh
+
+echo "Cleaning old anonymous volumes"
+docker volume ls -qf dangling=true | egrep '^[a-z0-9]{64}$' | \
+  xargs --no-run-if-empty docker volume rm
+
 docker-compose up -d nginx

--- a/script/stop
+++ b/script/stop
@@ -1,2 +1,6 @@
-#!/bin/bash
+#!/bin/sh
 docker-compose down
+
+echo "Cleaning old anonymous volumes"
+docker volume ls -qf dangling=true | egrep '^[a-z0-9]{64}$' | \
+  xargs --no-run-if-empty docker volume rm

--- a/tilebuilder/Dockerfile
+++ b/tilebuilder/Dockerfile
@@ -1,12 +1,26 @@
 FROM debian:latest
-RUN apt-get update
-RUN apt-get install -y build-essential libsqlite3-dev zlib1g-dev git
-RUN apt-get install -y gdal-bin jq
-RUN cd etc; git clone https://github.com/mapbox/tippecanoe.git; \
-cd tippecanoe; make -j; make install
-RUN mkdir /script; cd /script; \
-touch convert.sh; chmod a+x convert.sh; \
-echo "echo 'Warning: No conversion script provided!\n\
+RUN apt-get update \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      build-essential \
+      ca-certificates \
+      gdal-bin \
+      git \
+      jq \
+      libsqlite3-dev \
+      zlib1g-dev \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN cd etc \
+ && git clone https://github.com/mapbox/tippecanoe.git
+RUN cd etc/tippecanoe \
+ && make -j \
+ && make install
+RUN mkdir /script \
+ && cd /script \
+ && echo "echo 'Warning: No conversion script provided!\n\
   Specify one by mounting a volume on this container at /script.\n\
-  The volume should contain an executable script named convert.sh'" >> convert.sh
+  The volume should contain an executable script named convert.sh'" >> convert.sh \
+ && chmod a+x convert.sh
 CMD /script/convert.sh
+


### PR DESCRIPTION
Dockerfile cleanup to run apt-get update at the same time of apt-get install. Removed extra copies of /node_modules directory using a .yarnrc file. Changed /app/log and /app/tmp to a temporary volume and added anonymous volume cleanup commands to start/stop script. Changed the rails entrypoint to use the json syntax when launching the command and an exec at the end of the entrypoint to avoid a shell remaining as pid 1 (this helps with signal handling). 