### PR TITLE
Removing yarnrc from build process

### DIFF
--- a/rails/.yarnrc
+++ b/rails/.yarnrc
@@ -1,1 +1,0 @@
---modules-folder ../node_modules

--- a/rails/Dockerfile
+++ b/rails/Dockerfile
@@ -17,9 +17,11 @@ ENV RAILS_ENV=development
 RUN mkdir /app
 WORKDIR /app
 
-COPY Gemfile Gemfile.lock package.json yarn.lock .yarnrc ./
+COPY Gemfile Gemfile.lock package.json yarn.lock ./
 RUN bundle install
-RUN yarn install
+RUN mkdir -p /node_modules \
+ && ln -sf ../node_modules \
+ && yarn install --modules-folder ../node_modules
 RUN bundle exec rails new .
 RUN mv yarn.lock /yarn.lock
 


### PR DESCRIPTION
This gets rid of the .yarnrc file from the project and goes back to a symlink during the build. Fixes #243 