### PR TITLE
Pause all videos when playing new video

### DIFF
--- a/rails/app/assets/javascripts/pause_all_videos.js
+++ b/rails/app/assets/javascripts/pause_all_videos.js
@@ -1,0 +1,15 @@
+// Pause All Playing Videos
+//
+// This function is called when a video is played (by binding to the `play`
+// event), and it used to stop any other videos from continuing to play.
+window.pauseAllVideos = function(elem){
+  var videos = document.querySelectorAll('video');
+  for (var i=0; i<videos.length; i++) {
+    if(videos[i] == elem) {
+      continue;
+    }
+    if (videos[i].played.length > 0 && !videos[i].paused) {
+      videos[i].pause();
+    }
+  }
+}

--- a/rails/app/javascript/components/StoryMedia.jsx
+++ b/rails/app/javascript/components/StoryMedia.jsx
@@ -53,6 +53,9 @@ class StoryMedia extends PureComponent {
         this.setState({ explicitVideoHeight: newExplicitVideoHeight });
         doBustCache();
       });
+      video.addEventListener('play', (event) => {
+        window.pauseAllVideos(event.target);
+      }, true);
     }
   }
 }


### PR DESCRIPTION

This adds a global JS function to pause all playing videos when playing a new video.

![A Jun-02-2019 14-02-44](https://user-images.githubusercontent.com/16963/58765255-26afcc80-853f-11e9-8953-d0dcc62906f3.gif)

The flow goes something like:

- Binds to the `play` event when creating the video component
- When `play` event is triggered, the target of the event is passed to `pauseAllVideos()`
- This looks up all `<video>` tags and pauses them (unless it was one from the event)

This is admittedly a janky hack that is not very reactive. After discussing with @mirandawang decided this was Good Enough™ for now, and if we want to refactor it to better fit into the framework we can.

This decision was a side effect of not me not understanding how to React properly (suggestions are welcome!).

Fixes #153 
