### PR TITLE
Issue 228 Dynamically Resize Card Heights

### DIFF
--- a/rails/app/javascript/components/StoryList.jsx
+++ b/rails/app/javascript/components/StoryList.jsx
@@ -23,6 +23,13 @@ class StoryList extends Component {
     onStoryClick: PropTypes.func
   };
 
+  componentWillReceiveProps() {
+    this.cache.clearAll();
+    if(this._list){
+      this._list.recomputeRowHeights();
+    }
+  }
+
   handleClickStory = (story, index) => {
     this.setState({
       activeStoryIndex: index
@@ -100,6 +107,7 @@ class StoryList extends Component {
         <div className="stories">
           <AutoSizer>
             {({height, width}) => {
+
               return (
                 <List
                   height={height}


### PR DESCRIPTION
Added a `componentWillRecieveProps` with a cache clear and recompute row heights to dynamically resize card heights in the StoryList component.

Note: `componentWillRecieveProps` is deprecated in React 16.3, possible alternative in newer versions is `getDerivedStateFromProps` 