### PR TITLE
Update StoryMedia.jsx with value removing button

### DIFF
--- a/rails/app/javascript/components/StoryMedia.jsx
+++ b/rails/app/javascript/components/StoryMedia.jsx
@@ -33,6 +33,7 @@ class StoryMedia extends PureComponent {
         height={explicitVideoHeight}
         playsInline
         controls
+        disablepictureinpicture='true'       
         controlsList='nodownload'
         key={file.url}
         ref="video"


### PR DESCRIPTION
This gets rid of the superfluous three dots button on the video player! Issue: https://github.com/Terrastories/terrastories/issues/258