### PR TITLE
WIP: 268 display import errors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,7 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.3)
+    docile (1.3.2)
     dotenv (2.7.5)
     dotenv-rails (2.7.5)
       dotenv (= 2.7.5)
@@ -150,6 +151,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    json (2.2.0)
     kaminari (1.1.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.1.1)
@@ -299,6 +301,11 @@ GEM
       childprocess (>= 0.5, < 3.0)
       rubyzip (~> 1.2, >= 1.2.2)
     shellany (0.0.1)
+    simplecov (0.17.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     spring (2.1.0)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -368,6 +375,7 @@ DEPENDENCIES
   rspec-rails
   sass-rails (~> 5.0)
   selenium-webdriver
+  simplecov
   spring
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data

--- a/app/controllers/admin/places_controller.rb
+++ b/app/controllers/admin/places_controller.rb
@@ -1,21 +1,5 @@
 module Admin
   class PlacesController < Admin::ApplicationController
-    # To customize the behavior of this controller,
-    # you can overwrite any of the RESTful actions. For example:
-    #
-    # def index
-    #   super
-    #   @resources = Place.
-    #     page(params[:page]).
-    #     per(10)
-    # end
-
-    # Define a custom finder by overriding the `find_resource` method:
-    # def find_resource(param)
-    #   Place.find_by!(slug: param)
-    # end
-
-    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
-    # for more information
+    include Import
   end
 end

--- a/app/controllers/admin/speakers_controller.rb
+++ b/app/controllers/admin/speakers_controller.rb
@@ -1,21 +1,5 @@
 module Admin
   class SpeakersController < Admin::ApplicationController
-    # To customize the behavior of this controller,
-    # you can overwrite any of the RESTful actions. For example:
-    #
-    # def index
-    #   super
-    #   @resources = Speaker.
-    #     page(params[:page]).
-    #     per(10)
-    # end
-
-    # Define a custom finder by overriding the `find_resource` method:
-    # def find_resource(param)
-    #   Speaker.find_by!(slug: param)
-    # end
-
-    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
-    # for more information
+    include Import
   end
 end

--- a/app/controllers/admin/stories_controller.rb
+++ b/app/controllers/admin/stories_controller.rb
@@ -1,21 +1,5 @@
 module Admin
   class StoriesController < Admin::ApplicationController
-    # To customize the behavior of this controller,
-    # you can overwrite any of the RESTful actions. For example:
-    #
-    # def index
-    #   super
-    #   @resources = Story.
-    #     page(params[:page]).
-    #     per(10)
-    # end
-
-    # Define a custom finder by overriding the `find_resource` method:
-    # def find_resource(param)
-    #   Story.find_by!(slug: param)
-    # end
-
-    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
-    # for more information
+    include Import
   end
 end

--- a/app/controllers/concerns/import.rb
+++ b/app/controllers/concerns/import.rb
@@ -1,0 +1,18 @@
+module Import
+  extend ActiveSupport::Concern
+
+  def import
+    if params[:file].nil?
+      flash[:error] = "No file was attached!"
+    else
+      begin
+        controller_name.classify.constantize.import(params[:file].read)
+        flash[:notice] = "Points were imported successfully!"
+      rescue ImportError => e
+        flash[:error] = e.message
+      end
+    end
+
+    redirect_to action: :index
+  end
+end

--- a/app/controllers/places_controller.rb
+++ b/app/controllers/places_controller.rb
@@ -61,19 +61,6 @@ class PlacesController < ApplicationController
     end
   end
 
-
-  def import_csv
-    if params[:file].nil?
-      redirect_back(fallback_location: root_path)
-      flash[:error] = "No file was attached!"
-    else
-      filepath = params[:file].read
-      Place.import_csv(filepath)
-      flash[:notice] = "Points were imported successfully!"
-      redirect_back(fallback_location: root_path)
-    end
-  end
-
 # delete photo attachment 
   def delete
     remove_attachment

--- a/app/controllers/speakers_controller.rb
+++ b/app/controllers/speakers_controller.rb
@@ -26,18 +26,6 @@ class SpeakersController < ApplicationController
     redirect_to speaker_path(@speaker)
   end
 
-  def import_csv
-    if params[:file].nil?
-      redirect_back(fallback_location: root_path)
-      flash[:error] = "No file was attached!"
-    else
-      filepath = params[:file].read
-      Speaker.import_csv(filepath)
-      flash[:notice] = "Speakers were imported successfully!"
-      redirect_back(fallback_location: root_path)
-    end
-  end
-
   private
 
   def speaker_params

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -33,18 +33,6 @@ class StoriesController < ApplicationController
     remove_attachment
   end
 
-  def import_csv
-    if params[:file].nil?
-      redirect_back(fallback_location: root_path)
-      flash[:error] = "No file was attached!"
-    else
-      filepath = params[:file].read
-      Story.import_csv(filepath)
-      flash[:notice] = "Stories were imported successfully!"
-      redirect_back(fallback_location: root_path)
-    end
-  end
-
   private
 
   def story_params

--- a/app/errors/import_error.rb
+++ b/app/errors/import_error.rb
@@ -1,0 +1,1 @@
+class ImportError < StandardError; end

--- a/app/models/concerns/importable.rb
+++ b/app/models/concerns/importable.rb
@@ -1,0 +1,13 @@
+module Importable
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def importer(importer_klass)
+      @importer_klass = importer_klass
+    end
+
+    def import(data)
+      @importer_klass.new(data).import
+    end
+  end
+end

--- a/app/models/importing/base_importer.rb
+++ b/app/models/importing/base_importer.rb
@@ -1,0 +1,21 @@
+require 'csv'
+
+module Importing
+  class BaseImporter
+    def initialize(data)
+      @data = data
+    end
+
+    def import
+      ActiveRecord::Base.transaction do
+        CSV.parse(@data, headers: true) do |row|
+          import_row(row)
+        end
+      rescue StandardError => e
+        raise ImportError.new(e.message)
+      end
+    end
+
+    def import_row(row); end
+  end
+end

--- a/app/models/importing/places_importer.rb
+++ b/app/models/importing/places_importer.rb
@@ -5,8 +5,8 @@ module Importing
       place.type_of_place = row[1]
       place.description = row[2]
       place.region = row[3]
-      place.long = row[4].to_f
-      place.lat = row[5].to_f
+      place.lat = row[4].to_f
+      place.long = row[5].to_f
 
       if row[6] && File.exist?(Rails.root.join('media', row[6]))
         file = File.open(Rails.root.join('media',row[6]))

--- a/app/models/importing/places_importer.rb
+++ b/app/models/importing/places_importer.rb
@@ -1,0 +1,19 @@
+module Importing
+  class PlacesImporter < BaseImporter
+    def import_row(row)
+      place = Place.find_or_create_by(name: row[0])
+      place.type_of_place = row[1]
+      place.description = row[2]
+      place.region = row[3]
+      place.long = row[4].to_f
+      place.lat = row[5].to_f
+
+      if row[6] && File.exist?(Rails.root.join('media', row[6]))
+        file = File.open(Rails.root.join('media',row[6]))
+        place.photo.attach(io: file, filename: row[6])
+      end
+
+      place.save!
+    end
+  end
+end

--- a/app/models/importing/speakers_importer.rb
+++ b/app/models/importing/speakers_importer.rb
@@ -1,0 +1,22 @@
+module Importing
+  class SpeakersImporter < BaseImporter
+    def import_row(row)
+      speaker = Speaker.find_or_create_by(name: row[0])
+      speaker.birthplace = get_birthplace(row[2])
+      # Assumes birth date field is always just a year
+      speaker.birthdate = row[1].nil? || row[1].downcase == 'unknown' ? nil : Date.strptime(row[1], "%Y")
+      if row[3] && File.exist?(Rails.root.join('media', row[3]))
+        file = File.open(Rails.root.join('media',row[3]))
+        speaker.photo.attach(io: file, filename: row[3])
+      end
+      speaker.save!
+    end
+
+    def get_birthplace(name)
+      if name.nil? || name.downcase == 'unknown'
+        return nil
+      end
+      Place.find_or_create_by(name: name)
+    end
+  end
+end

--- a/app/models/importing/stories_importer.rb
+++ b/app/models/importing/stories_importer.rb
@@ -1,0 +1,62 @@
+module Importing
+  class StoriesImporter < BaseImporter
+    def import_row(row)
+      story = Story.new(title: row[0])
+      story.desc = row[1]
+      # add each spaker to the story, split by comma
+      speaker_names = row[2]
+      speaker_names.split(',').each do |speaker|
+        story.speakers << Speaker.find_or_create_by(name: speaker.strip)
+      end
+      # add each place to the story, split by comma
+      place_names = row[3]
+      place_names.split(',').each do |place|
+        story.places << Place.find_or_create_by(name: place.strip)
+      end
+      # Add interview location
+      story.interview_location = row[4].blank? ? nil : Place.find_or_create_by(name: row[4])
+      # Add interview date
+      story.date_interviewed = row[5].blank? ? nil : Date.strptime(row[5], "%m/%d/%y")
+      # Add interviewer
+      story.interviewer = row[6].blank? ? nil : Speaker.find_or_create_by(name: row[6])
+      # Add Language
+      story.language = row[7].blank? ? nil : row[7]
+
+      if row[8] && File.exist?(Rails.root.join('media', row[8]))
+        file = File.open(Rails.root.join('media',row[8]))
+        story.media.attach(io: file, filename: row[8])
+      end
+
+      story.permission_level = row[9].blank? ? "anonymous" : "user_only"
+      story.save!
+    end
+
+    private def import_speakers(story, speakers)
+      raise ImportError.new('Speakers cannot be empty!') unless speakers.present?
+
+      speakers.split(',').each do |speaker|
+        story.speakers << Speaker.find_or_create_by!(name: speaker.strip)
+      end
+    end
+
+    private def import_places(story, places)
+      raise ImportError.new('Places cannot be empty!') unless places.present?
+
+      places.split(',').each do |place|
+        story.places << Place.find_or_create_by!(name: place.strip)
+      end
+    end
+
+    private def import_interview_location(story, location)
+      if location.present?
+        story.interview_location = Place.find_or_create_by!(name: location.strip)
+      end
+    end
+
+    private def import_interviewer(story, interviewer)
+      if interviewer.present?
+        story.interviewer = Speaker.find_or_create_by!(name: interviewer.strip)
+      end
+    end
+  end
+end

--- a/app/models/importing/stories_importer.rb
+++ b/app/models/importing/stories_importer.rb
@@ -3,23 +3,12 @@ module Importing
     def import_row(row)
       story = Story.new(title: row[0])
       story.desc = row[1]
-      # add each spaker to the story, split by comma
-      speaker_names = row[2]
-      speaker_names.split(',').each do |speaker|
-        story.speakers << Speaker.find_or_create_by(name: speaker.strip)
-      end
-      # add each place to the story, split by comma
-      place_names = row[3]
-      place_names.split(',').each do |place|
-        story.places << Place.find_or_create_by(name: place.strip)
-      end
-      # Add interview location
-      story.interview_location = row[4].blank? ? nil : Place.find_or_create_by(name: row[4])
-      # Add interview date
-      story.date_interviewed = row[5].blank? ? nil : Date.strptime(row[5], "%m/%d/%y")
-      # Add interviewer
-      story.interviewer = row[6].blank? ? nil : Speaker.find_or_create_by(name: row[6])
-      # Add Language
+
+      import_speakers(story, row[2])
+      import_places(story, row[3])
+      import_interview_location(story, row[4])
+      story.date_interviewed = row[5].blank? ? nil : Date.strptime(row[5], "%m/%d/%Y")
+      import_interviewer(story, row[6])
       story.language = row[7].blank? ? nil : row[7]
 
       if row[8] && File.exist?(Rails.root.join('media', row[8]))

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -1,27 +1,14 @@
 class Place < ApplicationRecord
-  require 'csv'
+  include Importable
+
+  importer Importing::PlacesImporter
+
   has_and_belongs_to_many :stories
   has_one_attached :photo
-  validate :photo_format
   has_many :interview_stories, class_name: "Story", foreign_key: "interview_location_id"
+  validate :photo_format
 
   attr_reader :point_geojson
-
-  def self.import_csv(filename)
-    CSV.parse(filename, headers: true) do |row|
-      place = Place.find_or_create_by(name: row[0])
-      place.lat = row[5].to_f
-      place.long = row[4].to_f
-      place.type_of_place = row[1]
-      place.description = row[2]
-      place.region = row[3]
-      if row[6] && File.exist?(Rails.root.join('media', row[6]))
-        file = File.open(Rails.root.join('media',row[6]))
-        place.photo.attach(io: file, filename: row[6])
-      end
-      place.save
-    end
-  end
 
   def photo_format
     return unless photo.attached?

--- a/app/models/speaker.rb
+++ b/app/models/speaker.rb
@@ -13,6 +13,10 @@
 # updated_at  ... datetime, not null
 
 class Speaker < ApplicationRecord
+  include Importable
+
+  importer Importing::SpeakersImporter
+
   has_many :speaker_stories
   has_many :stories, through: :speaker_stories
   belongs_to :birthplace, class_name: "Place",  optional: true
@@ -25,26 +29,5 @@ class Speaker < ApplicationRecord
     else
       ActionController::Base.helpers.image_path('speaker.png', only_path: true)
     end
-  end
-
-  def self.import_csv(filename)
-    CSV.parse(filename, headers: true) do |row|
-      speaker = Speaker.find_or_create_by(name: row[0])
-      speaker.birthplace = get_birthplace(row[2])
-      # Assumes birth date field is always just a year
-      speaker.birthdate = row[1].nil? || row[1].downcase == 'unknown' ? nil : Date.strptime(row[1], "%Y")
-      if row[3] && File.exist?(Rails.root.join('media', row[3]))
-        file = File.open(Rails.root.join('media',row[3]))
-        speaker.photo.attach(io: file, filename: row[3])
-      end
-      speaker.save
-    end
-  end
-
-  def self.get_birthplace(name)
-    if name.nil? || name.downcase == 'unknown'
-      return nil
-    end
-    Place.find_or_create_by(name: name)
   end
 end

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -7,8 +7,8 @@ class Story < ApplicationRecord
   has_many :speakers, through: :speaker_stories
   has_many_attached :media
   has_and_belongs_to_many :places
-  belongs_to :interview_location, class_name: "Place", foreign_key: "interview_location_id"
-  belongs_to :interviewer, class_name: "Speaker", foreign_key: "interviewer_id"
+  belongs_to :interview_location, class_name: "Place", foreign_key: "interview_location_id", optional: true
+  belongs_to :interviewer, class_name: "Speaker", foreign_key: "interviewer_id", optional: true
 
   enum permission_level: [:anonymous, :user_only, :editor_only]
 end

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -1,41 +1,14 @@
 class Story < ApplicationRecord
+  include Importable
+
+  importer Importing::StoriesImporter
+
   has_many :speaker_stories
   has_many :speakers, through: :speaker_stories
   has_many_attached :media
   has_and_belongs_to_many :places
   belongs_to :interview_location, class_name: "Place", foreign_key: "interview_location_id"
   belongs_to :interviewer, class_name: "Speaker", foreign_key: "interviewer_id"
-
-  def self.import_csv(filename)
-    CSV.parse(filename, headers: true) do |row|
-      story = Story.new(title: row[0])
-      story.desc = row[1]
-      # add each spaker to the story, split by comma
-      speaker_names = row[2]
-      speaker_names.split(',').each do |speaker|
-        story.speakers << Speaker.find_or_create_by(name: speaker.strip)
-      end
-      # add each place to the story, split by comma
-      place_names = row[3]
-      place_names.split(',').each do |place|
-        story.places << Place.find_or_create_by(name: place.strip)
-      end
-      # Add interview location
-      story.interview_location = row[4].blank? ? nil : Place.find_or_create_by(name: row[4])
-      # Add interview date
-      story.date_interviewed = row[5].blank? ? nil : Date.strptime(row[5], "%m/%d/%y")
-      # Add interviewer
-      story.interviewer = row[6].blank? ? nil : Speaker.find_or_create_by(name: row[6])
-      # Add Language
-      story.language = row[7].blank? ? nil : row[7]
-      if row[8] && File.exist?(Rails.root.join('media', row[8]))
-        file = File.open(Rails.root.join('media',row[8]))
-        story.media.attach(io: file, filename: row[8])
-      end
-      story.permission_level = row[9].blank? ? "anonymous" : "user_only"
-      story.save
-    end
-  end
 
   enum permission_level: [:anonymous, :user_only, :editor_only]
 end

--- a/app/views/admin/application/index.html.erb
+++ b/app/views/admin/application/index.html.erb
@@ -66,7 +66,7 @@ It renders the `_table` partial to display details about the resources.
 </section>
 
 <% if ["place", "story", "speaker"].include?(page.resource_name) %>
-  <%= form_tag send("import_csv_#{page.resource_name.pluralize}_path"), multipart: true do %>
+  <%= form_tag send("import_admin_#{page.resource_name.pluralize}_path"), multipart: true do %>
     <div class="form-group">
       <label for="file"><%= t("administrate.file_to_update") %></label><%= file_field_tag :file, :accept => 'text/csv', class: "form-control-file" %>
     </div>

--- a/app/views/admin/application/index.html.erb
+++ b/app/views/admin/application/index.html.erb
@@ -65,20 +65,22 @@ It renders the `_table` partial to display details about the resources.
   <%= paginate resources %>
 </section>
 
-<% if ["place", "story", "speaker"].include?(page.resource_name) %>
-  <%= form_tag send("import_admin_#{page.resource_name.pluralize}_path"), multipart: true do %>
-    <div class="form-group">
-      <label for="file"><%= t("administrate.file_to_update") %></label><%= file_field_tag :file, :accept => 'text/csv', class: "form-control-file" %>
-    </div>
-    <br>
-    <div class="form-group">
-        <%= button_tag :class => "btn-import",
-              :data => {
-                :disable_with => 'Uploading your file...',
-              } do %>
-        <i class="fa fa-upload"></i><%= t("administrate.import_button", resource: t("administrate.#{page.resource_name.pluralize}")) %>
-      <% end %>
-      <i class="fa fa-spinner fa-spin fa-lg import-spinner"></i>
-    </div>
+<section class="main-content__body">
+  <% if ["place", "story", "speaker"].include?(page.resource_name) %>
+    <%= form_tag send("import_admin_#{page.resource_name.pluralize}_path"), multipart: true do %>
+      <div class="form-group">
+        <label for="file"><%= t("administrate.file_to_update") %></label><%= file_field_tag :file, :accept => 'text/csv', class: "form-control-file" %>
+      </div>
+      <br>
+      <div class="form-group">
+          <%= button_tag :class => "btn-import",
+                :data => {
+                  :disable_with => 'Uploading your file...',
+                } do %>
+          <i class="fa fa-upload"></i> <%= t("administrate.import_button", resource: t("administrate.#{page.resource_name.pluralize}")) %>
+        <% end %>
+        <i class="fa fa-spinner fa-spin fa-lg import-spinner"></i>
+      </div>
+    <% end %>
   <% end %>
-<% end %>
+</section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,9 +7,9 @@ Rails.application.routes.draw do
 
   namespace :admin do
     resources :users
-    resources :speakers
-    resources :stories
-    resources :places
+    resources :speakers, concerns: :import
+    resources :stories, concerns: :import
+    resources :places, concerns: :import
 
     root to: "users#index"
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,10 @@
 Rails.application.routes.draw do
+  concern :import do
+    collection do
+      post :import
+    end
+  end
+
   namespace :admin do
     resources :users
     resources :speakers
@@ -8,8 +14,8 @@ Rails.application.routes.draw do
     root to: "users#index"
   end
 
-    delete '/admin/places' => 'places#delete'
-    delete '/admin/stories' => 'stories#delete'
+  delete '/admin/places' => 'places#delete'
+  delete '/admin/stories' => 'stories#delete'
 
   scope "(:locale)", locale: Regexp.union(I18n.available_locales.map(&:to_s)) do
     resources :places do

--- a/public/packs/manifest.json
+++ b/public/packs/manifest.json
@@ -1,8 +1,8 @@
 {
-  "application.js": "/packs/application-bcf90f0a2e307a66eaaf.js",
-  "application.js.map": "/packs/application-bcf90f0a2e307a66eaaf.js.map",
+  "application.js": "/packs/application-aee11e31a1bc74277600.js",
+  "application.js.map": "/packs/application-aee11e31a1bc74277600.js.map",
   "hello_react.js": "/packs/hello_react-4c935fd53b9a51434fb2.js",
   "hello_react.js.map": "/packs/hello_react-4c935fd53b9a51434fb2.js.map",
-  "server_rendering.js": "/packs/server_rendering-c3b1058e43b515396b82.js",
-  "server_rendering.js.map": "/packs/server_rendering-c3b1058e43b515396b82.js.map"
+  "server_rendering.js": "/packs/server_rendering-6d1d4d4cfdd2a3043158.js",
+  "server_rendering.js.map": "/packs/server_rendering-6d1d4d4cfdd2a3043158.js.map"
 }

--- a/spec/models/importing/places_importer_spec.rb
+++ b/spec/models/importing/places_importer_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe Importing::PlacesImporter, type: :model do
+  let(:headers) { %w(Place_name Type_of_place Description Region lat long photo) }
+
+  let(:data) do
+    CSV.generate(headers: true) do |csv|
+      csv << headers
+      csv << attributes
+    end
+  end
+
+  let(:import) { Place.import(data) }
+
+  context 'general' do
+    let(:attributes) do
+      ['Lorem Ipsum', 'dang', 'Description', 'Iiba', 4.340923, -55.787912, nil]
+    end
+
+    it 'imports places from file' do
+      expect { Place.import(data) }.to change { Place.count }.by(1)
+
+      place = Place.find_by(name: attributes[0])
+
+      expect(place).to_not be_nil
+      expect(place.type_of_place).to eq(attributes[1])
+      expect(place.description).to eq(attributes[2])
+      expect(place.region).to eq(attributes[3])
+      expect(place.lat).to eq(attributes[4])
+      expect(place.long).to eq(attributes[5])
+    end
+  end
+
+  context 'with photo' do
+    let(:attributes) do
+      ['Lorem Ipsum', 'dang', 'Description', 'Iiba', 4.3409234, -55.7879123, 'test/test.png']
+    end
+
+    it 'attaches photo' do
+      import
+
+      place = Place.find_by(name: attributes[0])
+      expect(place.photo.attached?).to be true
+    end
+  end
+
+  context 'without photo' do
+    let(:attributes) do
+      ['Lorem Ipsum', 'dang', 'Description', 'Iiba', 4.3409234, -55.7879123, nil]
+    end
+
+    it 'does not attach photo' do
+      import
+
+      place = Place.find_by(name: attributes[0])
+      expect(place.photo.attached?).to be false
+    end
+  end
+end

--- a/spec/models/importing/speakers_importer_spec.rb
+++ b/spec/models/importing/speakers_importer_spec.rb
@@ -1,0 +1,115 @@
+require 'rails_helper'
+require 'csv'
+
+RSpec.describe Importing::SpeakersImporter, type: :model do
+  let(:headers) { %w(Speaker_name Birth_year Born_where Photo) }
+
+  let(:data) do
+    CSV.generate(headers: true) do |csv|
+      csv << headers
+      csv << attributes
+    end
+  end
+
+  let(:import) { Speaker.import(data) }
+
+  context 'general' do
+    let(:attributes) { ['Mary Frank', 1930, 'Suki', nil] }
+
+    it 'imports speakers from file' do
+
+      expect { import }.to change { Speaker.count }.by(1)
+
+      speaker = Speaker.find_by(name: attributes[0])
+
+      expect(speaker).to_not be_nil
+      expect(speaker.birthplace).to eq(Place.find_by(name: attributes[2]))
+      expect(speaker.birthdate).to eq(Date.new(attributes[1]))
+    end
+  end
+
+  context 'without photo' do
+    let(:attributes) { ['Mary Frank', 1930, 'Suki', nil] }
+
+    it 'does not attach photo' do
+      import
+      speaker = Speaker.find_by(name: attributes[0])
+      expect(speaker.photo.attached?).to be false
+    end
+  end
+
+  context 'with photo' do
+    let(:attributes) { ['Mary Frank', 1930, 'Suki', 'test/test.png'] }
+
+    it 'attaches photo' do
+      import
+      speaker = Speaker.find_by(name: attributes[0])
+      expect(speaker.photo.attached?).to be true
+    end
+
+  end
+
+  context 'with unknown birth year' do
+    let(:attributes) { ['Mary Frank', 'unknown', 'Suki', nil] }
+
+    it 'does not set birthdate' do
+      import
+      speaker = Speaker.find_by(name: attributes[0])
+      expect(speaker.birthdate).to be_nil
+    end
+  end
+
+  context 'wtihout birth year' do
+    let(:attributes) { ['Mary Frank', nil, 'Suki', 'speaker.png'] }
+
+    it 'does not set birthdate' do
+      import
+      speaker = Speaker.find_by(name: attributes[0])
+      expect(speaker.birthdate).to be_nil
+    end
+  end
+
+  context 'with birth year' do
+    let(:attributes) { ['Mary Frank', 1930, 'Suki', 'speaker.png'] }
+
+    it 'sets birthdate' do
+      import
+      speaker = Speaker.find_by(name: attributes[0])
+      expect(speaker.birthdate).to eq(Date.new(1930))
+    end
+  end
+
+  context 'with birth place' do
+    let(:attributes) { ['Mary Frank', 1930, 'Suki', nil] }
+
+    it 'creates new place' do
+      expect { import }.to change { Place.count }.by(1)
+
+      speaker = Speaker.find_by(name: attributes[0])
+      place = Place.find_by(name: attributes[2])
+      expect(speaker.birthplace).to eq(place)
+    end
+  end
+
+  context 'with unknown birth place' do
+    let(:attributes) { ['Mary Frank', 1930, 'unknown', nil] }
+
+    it 'creates no new place' do
+      expect { import }.to_not change { Place.count }
+
+      speaker = Speaker.find_by(name: attributes[0])
+      expect(speaker.birthplace).to be_nil
+    end
+  end
+
+  context 'without birth place' do
+    let(:attributes) { ['Mary Frank', 1930, nil, nil] }
+
+    it 'creates no new place' do
+      expect { import }.to_not change { Place.count }
+
+      speaker = Speaker.find_by(name: attributes[0])
+      expect(speaker.birthplace).to be_nil
+    end
+  end
+end

--- a/spec/models/importing/stories_importer_spec.rb
+++ b/spec/models/importing/stories_importer_spec.rb
@@ -1,0 +1,182 @@
+require 'rails_helper'
+
+RSpec.describe Importing::StoriesImporter, type: :model do
+  let(:headers) do
+    %w(Title_of_story
+       Description
+       Speaker_name
+       Place_name
+       Where_interviewed
+       Date_interview
+       Interviewer
+       Language
+       Video
+       Restricted_to_user)
+  end
+
+  let(:data) do
+    CSV.generate(headers: true) do |csv|
+      csv << headers
+      csv << attributes
+    end
+  end
+
+  let(:import) { Story.import(data) }
+  let(:attributes) do
+    ['The Story of Mary Frank', 'Some description', 'Mary Frank',
+     'Suki', 'New York', '10/09/2019', 'R. Sallon', 'Matawai', nil, 'yes']
+  end
+
+  context 'general' do
+    it 'imports stories from file' do
+      expect { import }.to change { Story.count }.by(1)
+
+      story = Story.find_by(title: attributes[0])
+
+      expect(story).to_not be_nil
+      expect(story.desc).to eq(attributes[1])
+      expect(story.date_interviewed.to_date).to eq(Date.today)
+      expect(story.language).to eq(attributes[7])
+      expect(story.permission_level).to eq('user_only')
+    end
+  end
+
+  shared_examples 'imports relations' do |model, relation_name, has_many, base_increment|
+    it "creates #{model.name.pluralize}" do
+      increment = base_increment + relations_attributes.size
+      expect { import }.to change { model.count }.by(increment)
+
+      story = Story.find_by(title: attributes[0])
+      if has_many
+        expect(story.public_send(relation_name).size).to eq(relations_attributes.size)
+      end
+
+      relations_attributes.each do |attrs|
+        relation = model.find_by(attrs)
+        expect(relation).to_not be_nil
+
+        if has_many
+          expect(story.public_send(relation_name)).to include(relation)
+        else
+          expect(story.public_send(relation_name)).to eq(relation)
+        end
+      end.empty? and begin
+        expect(story.public_send(relation_name)).to be_nil
+      end
+    end
+
+    it "does not create #{model.name.pluralize} when they exist" do
+      relations_attributes.each do |attrs|
+        model.create!(attrs)
+      end
+      expect { import }.to change { model.count }.by(base_increment)
+    end
+  end
+
+  context 'speakers' do
+    context 'with one speaker' do
+      let(:relations_attributes) { [{ name: attributes[2] }] }
+      it_behaves_like 'imports relations', Speaker, :speakers, true, 1
+    end
+
+    context 'with multiple speakers' do
+      before(:each) do
+        attributes[2] = 'Mary Frank, John Doe'
+      end
+
+      let(:relations_attributes) do
+        attributes[2].split(',').map do |name|
+          { name: name.strip }
+        end
+      end
+
+      it_behaves_like 'imports relations', Speaker, :speakers, true, 1
+    end
+
+    context 'with no speakers' do
+      it 'throws an error' do
+        attributes[2] = nil
+        expect { import }.to raise_error(ImportError, 'Speakers cannot be empty!')
+      end
+    end
+  end
+
+  context 'places' do
+    context 'with one place' do
+      let(:relations_attributes) { [{ name: attributes[3] }] }
+      it_behaves_like 'imports relations', Place, :places, true, 1
+    end
+
+    context 'with multiple places' do
+      before(:each) do
+        attributes[3] = 'Suki,Tokyo'
+      end
+
+      let(:relations_attributes) do
+        attributes[3].split(',').map do |name|
+          { name: name.strip }
+        end
+      end
+
+      it_behaves_like 'imports relations', Place, :places, true, 1
+    end
+
+    context 'with no places' do
+      it 'throws an error' do
+        attributes[3] = nil
+        expect { import }.to raise_error(ImportError, 'Places cannot be empty!')
+      end
+    end
+  end
+
+  context 'interview location' do
+    context 'present' do
+      let(:relations_attributes) { [{ name: attributes[4] }] }
+      it_behaves_like 'imports relations', Place, :interview_location, false, 1
+    end
+
+    context 'not present' do
+      before do
+        attributes[4] = nil
+      end
+
+      let(:relations_attributes) { [] }
+      it_behaves_like 'imports relations', Place, :interview_location, false, 1
+    end
+  end
+
+  context 'interviewer' do
+    context 'present' do
+      let(:relations_attributes) { [{ name: attributes[6] }] }
+      it_behaves_like 'imports relations', Speaker, :interviewer, false, 1
+    end
+
+    context 'not present' do
+      before do
+        attributes[6] = nil
+      end
+
+      let(:relations_attributes) { [] }
+      it_behaves_like 'imports relations', Speaker, :interviewer, false, 1
+    end
+  end
+
+  context 'permission level' do
+    context 'when blank' do
+      it 'it is set to anonymous' do
+        attributes[9] = nil
+        import
+        story = Story.find_by(title: attributes[0])
+        expect(story.permission_level).to eq('anonymous')
+      end
+    end
+
+    context 'when present' do
+      it 'it is set to anonymous' do
+        import
+        story = Story.find_by(title: attributes[0])
+        expect(story.permission_level).to eq('user_only')
+      end
+    end
+  end
+end

--- a/spec/models/place_spec.rb
+++ b/spec/models/place_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe Place, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it_behaves_like 'importable', 'places.csv'
 end

--- a/spec/models/speaker_spec.rb
+++ b/spec/models/speaker_spec.rb
@@ -1,7 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Speaker, type: :model do
-  
+
+  it_behaves_like 'importable', 'speakers.csv'
+
   let(:speaker) { Speaker.new(name: "Oliver Twist", birthdate: DateTime.new(1992))  }
 
   describe "attributes" do
@@ -9,6 +11,5 @@ RSpec.describe Speaker, type: :model do
       expect(speaker).to have_attributes(name: "Oliver Twist", birthdate: DateTime.new(1992))
     end
   end
-
 
 end

--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe Story, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it_behaves_like 'importable', 'stories.csv'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,8 @@ require 'factory_bot'
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
+  Dir["./spec/support/**/*.rb"].sort.each { |f| require f }
+
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.

--- a/spec/support/data/import/places.csv
+++ b/spec/support/data/import/places.csv
@@ -1,0 +1,3 @@
+Place_name (text field),Type_of_place (tag field),Description,Region (tag field),lat,long
+LoremIpsum,dang,"Lorem ipsum dolor sit amet, consectetur adipiscing elit.",Iiba,-55.7879123,4.3409234
+IpsumLorem,foisten konde,,Dendu,-55.7105555,4.5541234

--- a/spec/support/data/import/speakers.csv
+++ b/spec/support/data/import/speakers.csv
@@ -1,0 +1,3 @@
+Speaker_name (text field),Birth_year (text field),Born_where (tag field),Photo (file upload field)
+Mary Frank,1930,Suki,Mary.jpg
+Chris Beth,1950,,ChrisBeth.jpg

--- a/spec/support/data/import/stories.csv
+++ b/spec/support/data/import/stories.csv
@@ -1,0 +1,3 @@
+Title_of_story (text field),Description (text field),Speaker_name (tag field) - linked to Speaker name,Place_name (tag field) - linked to Place name,Where_interviewed (tag field),Date_interview (date field),Interviewer (tag field),Language (tag field),Video (file upload),Restricted_to_user (tag field)
+The Story of Mary Frank,lorem ipsum,Mary Frank,Lorem,Suki,4/12/2017,R. Sallon,Matawai,video1.mp4,Matawai
+Turk Story,,Chris Beth,"LoremIpsum, Lorem",Turk,2/20/2015,R. Sallon,Matawai,video2.mp4,Matawai

--- a/spec/support/shared_examples/importable.rb
+++ b/spec/support/shared_examples/importable.rb
@@ -1,0 +1,13 @@
+shared_examples 'importable' do |file|
+  let(:data) do
+    File.open(Rails.root.join('spec', 'support', 'data', 'import', file)).read
+  end
+
+  it 'imports model entries' do
+    initial_count = described_class.all.size
+
+    described_class.import(data)
+
+    expect(described_class.all.size).to be > initial_count
+  end
+end


### PR DESCRIPTION
This pull request introduces the following:

- The Import concern allows any controller to have import action that invokes the import method of its model. Additionally we have a similar concern in the routes as well.
- The Importable concern allows any model to support import by providing the importer class to be used. It expects the importer instance to be initialized with some data and respond to import.
- The base importer class is a template class for CSV importing. To create an importer for specific model, inherit from the base importer and define the import_row method for that specific model.
- Importers for the Place, Speaker and Story models. Implements the Importable and Import concerns in the models and their respective controllers. Clears out the importing code from the models and adds some DRY to the importing.
- Specs for the importable concern and the importers. Includes Stories, Speakers and Places importers.
- Marks `interview_location` and `interviewer` relations of the Story class as optional as per Rails 5+
- Minor UI fixes and visualisation of importing errors in the Admin area.