### PR TITLE
Updated SETUP.md with some solutions for possible errors in Ubuntu/Linux

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -26,6 +26,8 @@ Install docker. On linux, you may have to install docker-compose separately.
 On Windows, all terminal docker commands need to be run using Windows PowerShell, not Command Prompt.
 PowerShell comes with Windows.
 
+On Linux, users should run all docker commands with `sudo` or check the [official documentation](https://docs.docker.com/install/linux/linux-postinstall/) to manage Docker as a non-root user.
+
 ## Setup and running the server
 
 First update your `.env` file using `.env.example` as a reference. You will need a Mapbox token. You can obtain one for free by signing up [on Mapbox](https://mapbox.com/signup)
@@ -42,6 +44,14 @@ This will download and build all the docker images used in this project. Upon co
 ...
 Successfully tagged terrastories:latest
 ```
+
+**Linux** users should also run:
+
+```
+$ sudo docker-compose run web yarn install
+```
+
+for webpack to be loaded.
 
 The first time, run the following command to create your database and run the necessary migrations:
 


### PR DESCRIPTION
Hello!

I encountered some errors while I was setting-up the project. I experienced the same errors in two different distros: Ubuntu 16.04 LTS 64 and Ubuntu 18.04.3 LTS 64 so this is a tentative update for the SETUP instructions.

The first error is related to permissions and got help from the Terrastories' slack channel :smile_cat:. On linux you have to run docker commands as a super user or add some [extra configurations](https://docs.docker.com/install/linux/linux-postinstall/). If you don't do any of those the build will fail.

The second problem was related with Webpacker's installation. Docker doesn't fail and actually builds the project but every route (with the exception of /) will render a white page.

![Screenshot from 2019-10-12 20-01-17](https://user-images.githubusercontent.com/20052127/66708692-17c9f980-ed2b-11e9-82b6-2e4c6a90303a.png)

 This is my first docker project so I'm not an expert. I searched on the web for the exact same error and encountered [this issue](https://github.com/thepracticaldev/dev.to/issues/1001), applied the [solution ](https://github.com/thepracticaldev/dev.to/pull/1354) and finally got it to work. The routes show content and Webpack doesn't fail.

![Screenshot from 2019-10-12 20-09-06](https://user-images.githubusercontent.com/20052127/66708760-311f7580-ed2c-11e9-8afd-614638ecceef.png)


If you think I should change something please let me know!

