### PR TITLE
[#296] Add bundle and migrate to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,11 @@ services:
       - db
     ports:
       - 3000:3000
-    command: ["./scripts/wait-for-it.sh", "db:5432", "--", "./scripts/start_rails.sh"]
+    command: [
+      "./scripts/wait-for-it.sh",
+      "db:5432",
+      "--",
+      "./scripts/start_rails.sh"
+    ]
     volumes:
       - .:/opt/terrastories:cached

--- a/scripts/start_rails.sh
+++ b/scripts/start_rails.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-rm -f tmp/pids/server.pid && bundle exec rails s -b 0.0.0.0
+rm -f tmp/pids/server.pid && bundle && rails db:migrate && bundle exec rails s -b 0.0.0.0


### PR DESCRIPTION
Execute `bundle` and `rails db:migrate` on `docker-compose up`. This
helps to manage the dev environment easier when there are new gems or
migrations added to the project. The developer only needs to stop the
running container and run `docker-compose up` to get everything up to
speed.

Fixes #296 