### PR TITLE
use scrollToPosition List method in Filter event handlers

### DIFF
--- a/app/javascript/components/StoryList.jsx
+++ b/app/javascript/components/StoryList.jsx
@@ -52,10 +52,16 @@ class StoryList extends Component {
 
   handleFilter = (category, item) => {
     this.props.handleFilter(category, item);
+    this._list.scrollToPosition(0);
   }
 
   getStorySpeakerNames = story => {
     return story.speakers.map(function(speaker) { return speaker.name }).join(',');
+  }
+
+  handleClearFilteredStories = () => {
+    this.props.clearFilteredStories();
+    this._list.scrollToPosition(0);
   }
 
   renderStory = ({ key, index, style, parent }) => {
@@ -115,7 +121,7 @@ class StoryList extends Component {
             handleFilter={this.handleFilter}
             categories={this.props.categories}
             filterMap={this.props.filterMap}
-            clearFilteredStories={this.props.clearFilteredStories}
+            clearFilteredStories={this.handleClearFilteredStories}
           />
           <Sort
             stories={this.props.stories}


### PR DESCRIPTION
Hello!

I used the `scrollToPosition` List method inside `StoryList.handleFilter` to reset the sidebar scroll position to the top after applying filters and it seems to work as expected.

For the same reset to happen when clearing filters, I added a `handleClearFilteredStories` to StoryList that runs `clearFilteredStories` before resetting the sidebar scroll position.
