### PR TITLE
[#226] Frame map view around filtered stories

### DIFF
--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -9,7 +9,8 @@ class App extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      pointCoords: [],
+      framedView: null, // store information about how view should be laid out
+      pointCoords: [], // TODO: replace usage with framedView
       points: {},
       stories: this.props.stories,
       activePoint: null,
@@ -106,7 +107,14 @@ class App extends Component {
     }
     if (filteredStories) {
       const filteredPoints = this.getPointsFromStories(filteredStories);
-      this.setState({ stories: filteredStories, points: filteredPoints, pointCoords: [] });
+
+      const framedView = {
+        center: [-108, 38.5],
+        zoom: 8.5,
+        pitch: 0,
+        bearing: 0
+      };
+      this.setState({ stories: filteredStories, points: filteredPoints, framedView });
     }
   }
 
@@ -144,7 +152,7 @@ class App extends Component {
   handleMapPointClick = (point, stories) => {
     console.log(point);
     this.showMapPointStories(stories);
-    this.setState({activePoint: point, pointCoords: point.geometry.coordinates});
+    this.setState({activePoint: point, pointCoords: point.geometry.coordinates, framedView: null});
   }
 
   render() {
@@ -158,6 +166,7 @@ class App extends Component {
           clearFilteredStories={this.resetStoriesAndMap}
           onMapPointClick={this.handleMapPointClick}
           activePoint={this.state.activePoint}
+          framedView={this.state.framedView}
         />
         <Card
           activeStory={this.state.activeStory}

--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -10,7 +10,6 @@ class App extends Component {
     super(props);
     this.state = {
       framedView: null, // store information about how view should be laid out
-      pointCoords: [], // TODO: replace usage with framedView
       points: {},
       stories: this.props.stories,
       activePoint: null,
@@ -134,8 +133,8 @@ class App extends Component {
   handleStoryClick = story => {
     // set active to first point in story
     const point = story.points[0];
-    const pointCoords = point.geometry.coordinates;
-    this.setState({activePoint: point, activeStory: story, pointCoords: pointCoords});
+    const framedView = { center: point.geometry.coordinates };
+    this.setState({activePoint: point, activeStory: story, framedView});
   }
 
   resetStoriesAndMap = () => {
@@ -143,7 +142,7 @@ class App extends Component {
     this.setState({
       stories: this.props.stories,
       points: points,
-      pointCoords: [],
+      framedView: null,
       activePoint: null,
       activeStory: null
     });
@@ -152,7 +151,8 @@ class App extends Component {
   handleMapPointClick = (point, stories) => {
     console.log(point);
     this.showMapPointStories(stories);
-    this.setState({activePoint: point, pointCoords: point.geometry.coordinates, framedView: null});
+    const framedView = { center: point.geometry.coordinates };
+    this.setState({activePoint: point, framedView});
   }
 
   render() {
@@ -160,7 +160,6 @@ class App extends Component {
       <div>
         <Map
           points={this.state.points}
-          pointCoords={this.state.pointCoords}
           mapboxAccessToken={this.props.mapbox_access_token}
           mapboxStyle={this.props.mapbox_style}
           clearFilteredStories={this.resetStoriesAndMap}

--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -4,6 +4,7 @@ import Map from './Map';
 import Card from './Card';
 import IntroPopup from './IntroPopup';
 import {FILTER_CATEGORIES} from '../constants/FilterConstants';
+import bbox from "@turf/bbox";
 
 class App extends Component {
   constructor(props) {
@@ -32,8 +33,10 @@ class App extends Component {
 
   getPointsFromStories = stories => {
     const points = stories.map(story => story.points).flat();
-    const pointObj = {};
-    pointObj['features'] = points;
+    const pointObj = {
+      type: "FeatureCollection",
+      features: points
+    };
     return pointObj;
   }
 
@@ -106,12 +109,10 @@ class App extends Component {
     }
     if (filteredStories) {
       const filteredPoints = this.getPointsFromStories(filteredStories);
-
+      const bounds = bbox(filteredPoints);
       const framedView = {
-        center: [-108, 38.5],
-        zoom: 8.5,
-        pitch: 0,
-        bearing: 0
+        bounds,
+        maxZoom: 12
       };
       this.setState({ stories: filteredStories, points: filteredPoints, framedView });
     }

--- a/app/javascript/components/Map.jsx
+++ b/app/javascript/components/Map.jsx
@@ -45,7 +45,7 @@ export default class Map extends Component {
     this.map.addControl(new mapboxgl.NavigationControl());
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps) {
     // update popups
     // only display one at a time, remove all other popups
     const popupNodes = document.getElementsByClassName('mapboxgl-popup');
@@ -65,6 +65,12 @@ export default class Map extends Component {
       const popupNodes = document.getElementsByClassName('mapboxgl-marker');
       Array.from(popupNodes).forEach(node => node.remove());
       this.updateMarkers();
+    }
+
+    if (this.props.framedView) {
+      console.log("framed view: ", this.props.framedView)
+      this.map.easeTo({ ...this.props.framedView, duration: 2000.0 });
+      return;
     }
 
     if (this.props.pointCoords.length > 0) {
@@ -181,6 +187,7 @@ export default class Map extends Component {
   }
 
   render() {
+    console.log("map");
     return (
       <div ref={
         el => this.mapContainer = el

--- a/app/javascript/components/Map.jsx
+++ b/app/javascript/components/Map.jsx
@@ -20,7 +20,7 @@ export default class Map extends Component {
   static propTypes = {
     activePoint: PropTypes.object,
     points: PropTypes.object,
-    pointCoords: PropTypes.array,
+    framedView: PropTypes.object,
     onMapPointClick: PropTypes.func,
     mapboxStyle: PropTypes.string,
     mapboxAccessToken: PropTypes.string
@@ -68,15 +68,7 @@ export default class Map extends Component {
     }
 
     if (this.props.framedView) {
-      console.log("framed view: ", this.props.framedView)
       this.map.easeTo({ ...this.props.framedView, duration: 2000.0 });
-      return;
-    }
-
-    if (this.props.pointCoords.length > 0) {
-      if (this.map) {
-        this.map.panTo(this.props.pointCoords);
-      }
       return;
     } else {
       if (this.map) {

--- a/app/javascript/components/Map.jsx
+++ b/app/javascript/components/Map.jsx
@@ -68,7 +68,12 @@ export default class Map extends Component {
     }
 
     if (this.props.framedView) {
-      this.map.easeTo({ ...this.props.framedView, duration: 2000.0 });
+      const {bounds, ...frameOptions} = this.props.framedView;
+      if (bounds) {
+        this.map.fitBounds(bounds, { duration: 2000.0, ...frameOptions })
+      } else {
+        this.map.easeTo({ duration: 2000.0, ...frameOptions });
+      }
       return;
     } else {
       if (this.map) {
@@ -179,7 +184,6 @@ export default class Map extends Component {
   }
 
   render() {
-    console.log("map");
     return (
       <div ref={
         el => this.mapContainer = el

--- a/app/javascript/components/Map.jsx
+++ b/app/javascript/components/Map.jsx
@@ -67,7 +67,7 @@ export default class Map extends Component {
       this.updateMarkers();
     }
 
-    if (this.props.framedView) {
+    if (this.props.framedView && this.props.framedView !== prevProps.framedView) {
       const {bounds, ...frameOptions} = this.props.framedView;
       if (bounds) {
         this.map.fitBounds(bounds, { duration: 2000.0, ...frameOptions })

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   },
   "dependencies": {
     "@rails/webpacker": "3.5",
+    "@turf/bbox": "^6.0.1",
+    "@turf/helpers": "^6.1.4",
     "babel-jest": "^23.6.0",
     "babel-preset-react": "^6.24.1",
     "fstream": "1.0.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -133,6 +133,26 @@
   resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz#8013f2af54a2b7d735f71560ff360d3a8176a87b"
   integrity sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q==
 
+"@turf/bbox@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@turf/bbox/-/bbox-6.0.1.tgz#b966075771475940ee1c16be2a12cf389e6e923a"
+  integrity sha512-EGgaRLettBG25Iyx7VyUINsPpVj1x3nFQFiGS3ER8KCI1MximzNLsam3eXRabqQDjyAKyAE1bJ4EZEpGvspQxw==
+  dependencies:
+    "@turf/helpers" "6.x"
+    "@turf/meta" "6.x"
+
+"@turf/helpers@6.x", "@turf/helpers@^6.1.4":
+  version "6.1.4"
+  resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-6.1.4.tgz#d6fd7ebe6782dd9c87dca5559bda5c48ae4c3836"
+  integrity sha512-vJvrdOZy1ngC7r3MDA7zIGSoIgyrkWcGnNIEaqn/APmw+bVLF2gAW7HIsdTxd12s5wQMqEpqIQrmrbRRZ0xC7g==
+
+"@turf/meta@6.x":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@turf/meta/-/meta-6.0.2.tgz#eb92951126d24a613ac1b7b99d733fcc20fd30cf"
+  integrity sha512-VA7HJkx7qF1l3+GNGkDVn2oXy4+QoLP6LktXAaZKjuT1JI0YESat7quUkbCMy4zP9lAUuvS4YMslLyTtr919FA==
+  dependencies:
+    "@turf/helpers" "6.x"
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#42995b446db9a48a11a07ec083499a860e9138ff"


### PR DESCRIPTION
When filtering stories in the sidebar, the map now zooms and pans to the region containing those stories. This makes them better fill the available screen space.

## What changed
Replaced `pointCoords` with `framedView` object.
`framedView` allows for specifying either bounds to fit or other map properties to easeTo.
Handle changes to `framedView` prop in map to animate the map view.

## How to test
Launch the map view and confirm:
1) clicking on a story still focuses the story
2) filtering the set of stories in the sidebar reframes the map around those stories
3) removing the filter resets the map view

Closes #226