### PR TITLE
Removing autocomment for issues

### DIFF
--- a/.github/auto-comment.yml
+++ b/.github/auto-comment.yml
@@ -1,14 +1,3 @@
-issuesOpened: >
-  <img src="https://media.tenor.com/images/a44d0c84e5e535a649b16011b8d3c54c/tenor.gif" height=200 />
-  <br />
-  Thank you for raising a issue. We will try and get back to you as soon as possible.
-  <br />
-  Please make sure you have given us as much context as possible.
-  <br />
-  Best,
-  <br />
-  @terrastories-stewards
-
 pullRequestOpened: >
   <img src="https://media.giphy.com/media/LPx5F48jqLHd9ClF0L/giphy.gif" height=200 />
   <br />


### PR DESCRIPTION
Because it's getting annoying to manage our own tickets.
And adding some extra cruft to them.

I'd like to remove the issues autocomment until we can figure out a way to exclude ourselves.