### PR TITLE
Add i18n gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,9 @@ gem 'jbuilder', '~> 2.5'
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 
+gem 'rails-i18n'
 gem 'devise'
+gem 'devise-i18n'
 gem 'pundit'
 gem 'administrate'
 gem 'administrate-field-active_storage'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,8 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    devise-i18n (1.8.2)
+      devise (>= 4.6)
     diff-lcs (1.3)
     docile (1.3.2)
     dotenv (2.7.5)
@@ -235,6 +237,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.2.0)
       loofah (~> 2.2, >= 2.2.2)
+    rails-i18n (5.1.3)
+      i18n (>= 0.7, < 2)
+      railties (>= 5.0, < 6)
     railties (5.2.3)
       actionpack (= 5.2.3)
       activesupport (= 5.2.3)
@@ -361,6 +366,7 @@ DEPENDENCIES
   capybara (>= 2.15, < 4.0)
   chromedriver-helper
   devise
+  devise-i18n
   dotenv-rails
   factory_bot_rails
   font-awesome-rails (~> 4.7)
@@ -377,6 +383,7 @@ DEPENDENCIES
   pundit
   rails (~> 5.2.0)
   rails-controller-testing
+  rails-i18n
   react-rails
   rgeo-geojson
   rspec-rails


### PR DESCRIPTION
Added i18n related gems.
They save us by failing translation of common rails messages like validation error messages.

Here is an example:

Before)
![image](https://user-images.githubusercontent.com/1730718/67541629-9c057f00-f724-11e9-92e7-86def8617309.png)

After)
![image](https://user-images.githubusercontent.com/1730718/67541637-a3c52380-f724-11e9-8587-dfbf2053bd53.png)
