### PR TITLE
Fix users search on admin page

### DIFF
--- a/app/dashboards/user_dashboard.rb
+++ b/app/dashboards/user_dashboard.rb
@@ -11,7 +11,7 @@ class UserDashboard < Administrate::BaseDashboard
     id: Field::Number,
     email: Field::String,
     role: EnumField,
-    password: Field::String,
+    password: Field::String.with_options(searchable: false),
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
   }.freeze

--- a/app/dashboards/user_dashboard.rb
+++ b/app/dashboards/user_dashboard.rb
@@ -11,7 +11,7 @@ class UserDashboard < Administrate::BaseDashboard
     id: Field::Number,
     email: Field::String,
     role: EnumField,
-    password: Field::String.with_options(searchable: false),
+    password: Field::Password,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
   }.freeze


### PR DESCRIPTION
Excluded `password` field from searching targets.

Fix #358 