### PR TITLE
# 364 - clear filters upon closing Card

### DIFF
--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -6,6 +6,9 @@ import IntroPopup from "./IntroPopup";
 import FILTER_CATEGORIES from "../constants/FilterConstants";
 import bbox from "@turf/bbox";
 
+let DEFAULT_CATEGORY_PLACEHOLDER = I18n.t("select_category");
+let DEFAULT_ITEM_PLACEHOLDER = I18n.t("select_option");
+
 class App extends Component {
   constructor(props) {
     super(props);
@@ -14,8 +17,11 @@ class App extends Component {
       points: {},
       stories: this.props.stories,
       activePoint: null,
-      activeStory: null
-    };
+      activeStory: null,
+      filterCategory: DEFAULT_CATEGORY_PLACEHOLDER,
+      filterItem: DEFAULT_ITEM_PLACEHOLDER,
+      itemOptions: []
+    }
   }
 
   static propTypes = {
@@ -158,6 +164,26 @@ class App extends Component {
     }
   };
 
+  handleFilterCategoryChange = option => {
+    if (option === null) {
+      this.resetStoriesAndMap();
+    } else {
+      const category = option.value;
+      "Picked category ", category;
+      this.setState({ filterCategory: category, itemOptions: this.filterMap()[category] })
+    }
+  }
+
+  handleFilterItemChange = option => {
+    if (option === null) {
+      this.resetStoriesAndMap();
+    } else {
+      const item = option.value;
+      this.handleFilter(this.state.filterCategory, item);
+      this.setState({ filterItem: item });
+    }
+  }
+
   showMapPointStories = stories => {
     let storyTitles = stories.map(story => story.title);
     let filteredStories = [];
@@ -190,7 +216,9 @@ class App extends Component {
       points: points,
       framedView: null,
       activePoint: null,
-      activeStory: null
+      activeStory: null,
+      filterCategory: DEFAULT_CATEGORY_PLACEHOLDER,
+      filterItem: DEFAULT_ITEM_PLACEHOLDER
     });
   };
 
@@ -224,6 +252,11 @@ class App extends Component {
           onStoryClick={this.handleStoryClick}
           logo_path={this.props.logo_path}
           user={this.props.user}
+          filterCategory={this.state.filterCategory}
+          filterItem={this.state.filterItem}
+          handleFilterCategoryChange={this.handleFilterCategoryChange}
+          handleFilterItemChange={this.handleFilterItemChange}
+          itemOptions={this.state.itemOptions}
         />
         <IntroPopup />
       </div>

--- a/app/javascript/components/Card.jsx
+++ b/app/javascript/components/Card.jsx
@@ -21,7 +21,12 @@ class Card extends Component {
     handleStoriesChanged: PropTypes.func,
     onStoryClick: PropTypes.func,
     logo_path: PropTypes.string,
-    activeStory: PropTypes.object
+    activeStory: PropTypes.object,
+    filterCategory: PropTypes.string,
+    filterItem: PropTypes.string,
+    handleFilterCategoryChange: PropTypes.func,
+    handleFilterItemChange: PropTypes.func,
+    itemOptions: PropTypes.array
   };
 
   static defaultProps = {
@@ -82,6 +87,11 @@ class Card extends Component {
               clearFilteredStories={this.props.clearFilteredStories}
               filterMap={this.props.filterMap}
               categories={this.props.categories}
+              filterCategory={this.props.filterCategory}
+              filterItem={this.props.filterItem}
+              handleFilterCategoryChange={this.props.handleFilterCategoryChange}
+              handleFilterItemChange={this.props.handleFilterItemChange}
+              itemOptions={this.props.itemOptions}
             />
 
             <div className="card--tasks">

--- a/app/javascript/components/Filter.jsx
+++ b/app/javascript/components/Filter.jsx
@@ -6,38 +6,9 @@ const Filter = props => {
   let DEFAULT_CATEGORY_PLACEHOLDER = I18n.t("select_category");
   let DEFAULT_ITEM_PLACEHOLDER = I18n.t("select_option");
 
-  const [itemOptions, setItemOptions] = useState([]);
-  const [categorySelectValue, setCategorySelectValue] = useState(
-    DEFAULT_CATEGORY_PLACEHOLDER
-  );
-  const [itemSelectValue, setItemSelectValue] = useState(
-    DEFAULT_ITEM_PLACEHOLDER
-  );
+  const handleCategoryChange = option => props.handleFilterCategoryChange(option);
 
-  const handleCategoryChange = option => {
-    if (option === null) {
-      props.clearFilteredStories();
-      setCategorySelectValue(DEFAULT_ITEM_PLACEHOLDER);
-      setItemSelectValue(DEFAULT_ITEM_PLACEHOLDER);
-    } else {
-      const category = option.value;
-      "Picked category ", category;
-      setCategorySelectValue(category);
-      setItemOptions(props.filterMap[category]);
-      setItemSelectValue(DEFAULT_ITEM_PLACEHOLDER);
-    }
-  };
-
-  const handleItemChange = option => {
-    if (option === null) {
-      props.clearFilteredStories();
-      setItemSelectValue(DEFAULT_ITEM_PLACEHOLDER);
-    } else {
-      const item = option.value;
-      props.handleFilter(categorySelectValue, item);
-      setItemSelectValue(item);
-    }
-  };
+  const handleItemChange = option => props.handleFilterItemChange(option);
 
   const optionsHash = options => {
     return options.map(option => {
@@ -51,21 +22,21 @@ const Filter = props => {
       <Select
         className="categoryFilter"
         classNamePrefix="select"
-        value={optionsHash([categorySelectValue])}
+        value={optionsHash([props.filterCategory])}
         onChange={handleCategoryChange}
-        isClearable={categorySelectValue !== DEFAULT_CATEGORY_PLACEHOLDER}
+        isClearable={props.filterCategory !== DEFAULT_CATEGORY_PLACEHOLDER}
         name="filter-categories"
         options={optionsHash(props.categories)}
       />
       <Select
         className="itemFilter"
         classNamePrefix="select"
-        value={optionsHash([itemSelectValue])}
+        value={optionsHash([props.filterItem])}
         onChange={handleItemChange}
-        isClearable={itemSelectValue !== DEFAULT_ITEM_PLACEHOLDER}
+        isClearable={props.filterItem !== DEFAULT_ITEM_PLACEHOLDER}
         isSearchable={true}
         name="filter-items"
-        options={optionsHash(itemOptions)}
+        options={optionsHash(props.itemOptions)}
       />
     </React.Fragment>
   );
@@ -75,7 +46,10 @@ Filter.propTypes = {
   categories: PropTypes.array,
   filterMap: PropTypes.object,
   clearFilteredStories: PropTypes.func,
-  handleFilter: PropTypes.func
+  handleFilter: PropTypes.func,
+  handleFilterCategoryChange: PropTypes.func,
+  handleFilterItemChange: PropTypes.func,
+  itemOptions: PropTypes.array
 };
 
 Filter.defaultProps = {

--- a/app/javascript/components/Filter.jsx
+++ b/app/javascript/components/Filter.jsx
@@ -1,100 +1,87 @@
-import React, { Component } from 'react';
-import Select from 'react-select';
-import PropTypes from 'prop-types';
+import React, { useState } from "react";
+import Select from "react-select";
+import PropTypes from "prop-types";
 
-class Filter extends Component {
+const Filter = props => {
+  let DEFAULT_CATEGORY_PLACEHOLDER = I18n.t("select_category");
+  let DEFAULT_ITEM_PLACEHOLDER = I18n.t("select_option");
 
-  DEFAULT_CATEGORY_PLACEHOLDER = I18n.t("select_category");
-  DEFAULT_ITEM_PLACEHOLDER = I18n.t("select_option");
+  const [itemOptions, setItemOptions] = useState([]);
+  const [categorySelectValue, setCategorySelectValue] = useState(
+    DEFAULT_CATEGORY_PLACEHOLDER
+  );
+  const [itemSelectValue, setItemSelectValue] = useState(
+    DEFAULT_ITEM_PLACEHOLDER
+  );
 
-  constructor(props){
-    super(props);
-    this.state = {
-      itemOptions: [],
-      categorySelectValue: this.DEFAULT_CATEGORY_PLACEHOLDER,
-      itemSelectValue: this.DEFAULT_ITEM_PLACEHOLDER
-    };
-  }
-
-  static propTypes = {
-    categories: PropTypes.array,
-    filterMap: PropTypes.object,
-    clearFilteredStories: PropTypes.func,
-    handleFilter: PropTypes.func
-  };
-
-  static defaultProps = {
-    categories: [],
-    filterMap: {},
-    clearFilteredStories: () => {}
-  };
-
-  handleCategoryChange = option => {
+  const handleCategoryChange = option => {
     if (option === null) {
-      this.props.clearFilteredStories();
-      this.setState({
-        itemOptions: [],
-        categorySelectValue: this.DEFAULT_CATEGORY_PLACEHOLDER,
-        itemSelectValue: this.DEFAULT_ITEM_PLACEHOLDER
-      });
+      props.clearFilteredStories();
+      setCategorySelectValue(DEFAULT_ITEM_PLACEHOLDER);
+      setItemSelectValue(DEFAULT_ITEM_PLACEHOLDER);
     } else {
       const category = option.value;
-      ('Picked category ', category);
-      this.setState({
-        categorySelectValue: category,
-        itemOptions: this.props.filterMap[category],
-        itemSelectValue: this.DEFAULT_ITEM_PLACEHOLDER
-      });
+      "Picked category ", category;
+      setCategorySelectValue(category);
+      setItemOptions(props.filterMap[category]);
+      setItemSelectValue(DEFAULT_ITEM_PLACEHOLDER);
     }
-  }
+  };
 
-  handleItemChange = option => {
+  const handleItemChange = option => {
     if (option === null) {
-      this.props.clearFilteredStories();
-      this.setState({
-        itemSelectValue: this.DEFAULT_ITEM_PLACEHOLDER
-      })
+      props.clearFilteredStories();
+      setItemSelectValue(DEFAULT_ITEM_PLACEHOLDER);
     } else {
       const item = option.value;
-      this.props.handleFilter(this.state.categorySelectValue, item);
-      this.setState({
-        itemSelectValue: item
-      });
+      props.handleFilter(categorySelectValue, item);
+      setItemSelectValue(item);
     }
-  }
+  };
 
-  optionsHash = options => {
+  const optionsHash = options => {
     return options.map(option => {
-      return {value: option, label: option};
+      return { value: option, label: option };
     });
-  }
+  };
 
-  render() {
-    return (
-      <React.Fragment>
-        <span className="card--nav-filter">{I18n.t("filter_stories")}: </span>
-        <Select
-          className="categoryFilter"
-          classNamePrefix="select"
-          value={this.optionsHash([this.state.categorySelectValue])}
-          onChange={this.handleCategoryChange}
-          isClearable={this.state.categorySelectValue !== this.DEFAULT_CATEGORY_PLACEHOLDER}
-          name="filter-categories"
-          options={this.optionsHash(this.props.categories)}
-        />
-        <Select
-          className="itemFilter"
-          classNamePrefix="select"
-          value={this.optionsHash([this.state.itemSelectValue])}
-          onChange={this.handleItemChange}
-          isClearable={this.state.itemSelectValue !== this.DEFAULT_ITEM_PLACEHOLDER}
-          isSearchable={true}
-          name="filter-items"
-          options={this.optionsHash(this.state.itemOptions)}
-        />
-      </React.Fragment>
-    );
-  }
-}
+  return (
+    <React.Fragment>
+      <span className="card--nav-filter">{I18n.t("filter_stories")}: </span>
+      <Select
+        className="categoryFilter"
+        classNamePrefix="select"
+        value={optionsHash([categorySelectValue])}
+        onChange={handleCategoryChange}
+        isClearable={categorySelectValue !== DEFAULT_CATEGORY_PLACEHOLDER}
+        name="filter-categories"
+        options={optionsHash(props.categories)}
+      />
+      <Select
+        className="itemFilter"
+        classNamePrefix="select"
+        value={optionsHash([itemSelectValue])}
+        onChange={handleItemChange}
+        isClearable={itemSelectValue !== DEFAULT_ITEM_PLACEHOLDER}
+        isSearchable={true}
+        name="filter-items"
+        options={optionsHash(itemOptions)}
+      />
+    </React.Fragment>
+  );
+};
+
+Filter.propTypes = {
+  categories: PropTypes.array,
+  filterMap: PropTypes.object,
+  clearFilteredStories: PropTypes.func,
+  handleFilter: PropTypes.func
+};
+
+Filter.defaultProps = {
+  categories: [],
+  filterMap: {},
+  clearFilteredStories: () => {}
+};
 
 export default Filter;

--- a/app/javascript/components/StoryList.jsx
+++ b/app/javascript/components/StoryList.jsx
@@ -23,7 +23,12 @@ class StoryList extends Component {
     onStoryClick: PropTypes.func,
     filterMap: PropTypes.object,
     categories: PropTypes.array,
-    activeStory: PropTypes.object
+    activeStory: PropTypes.object,
+    filterCategory: PropTypes.string,
+    filterItem: PropTypes.string,
+    handleFilterCategoryChange: PropTypes.func,
+    handleFilterItemChange: PropTypes.func,
+    itemOptions: PropTypes.array
   };
 
   // In React 16.3.0, update method to getSnapshotBeforeUpdate
@@ -122,6 +127,11 @@ class StoryList extends Component {
             categories={this.props.categories}
             filterMap={this.props.filterMap}
             clearFilteredStories={this.handleClearFilteredStories}
+            filterCategory={this.props.filterCategory}
+            filterItem={this.props.filterItem}
+            handleFilterCategoryChange={this.props.handleFilterCategoryChange}
+            handleFilterItemChange={this.props.handleFilterItemChange}
+            itemOptions={this.props.itemOptions}
           />
           <Sort
             stories={this.props.stories}


### PR DESCRIPTION
#364 
## Problem:
![filters_bad](https://user-images.githubusercontent.com/22733487/67736475-2af0f080-f9de-11e9-9920-18c4461a9bbd.gif)

When using the filters and viewing a Card on the map, if you close the Card, the filters don't get reset.

This is because the category and item filters were local to the `Filters` component, whereas the function that gets invoked when closing the card is much higher up in the state hierarchy, having no direct impact on the `Filters` local state.

## Solution
![filters_good](https://user-images.githubusercontent.com/22733487/67736580-8ae79700-f9de-11e9-9693-fc3072a6cc80.gif)

Hoist `Filters` state higher up into the `App` component, and instead pass the values down as `props`.

### Changes
* make the `Filters` component functional, as requested
* add to `App` state the following to be passed all the way down to the `Filters` component
    * `filterCategory`
    * `filterItem`
    * `itemOptions`
* add handler functions to `App` component to handle changes to the category and item filters, and pass these down to the `Filter` component as well
    * `handleFilterCategoryChange()`
    * `handleFilterItemChange()`
* update `props` passing through `Card` and `StoryList` components