### PR TITLE
Add a small lock emoji next to story title if the story permission_level is not anonymous

### DIFF
--- a/app/javascript/components/StoryList.jsx
+++ b/app/javascript/components/StoryList.jsx
@@ -103,7 +103,7 @@ class StoryList extends Component {
             }
           </div>
           <div className="container">
-            <h6 className="title">{story.title}</h6>
+            <h6 className="title">{ story.permission_level === "restricted" && "🔒" }{story.title}</h6>
             <p>{story.desc}</p>
             {story.media &&
               story.media.map(file => <StoryMedia file={file} doBustCache={bustCache} key={story.media.id} />)}

--- a/app/views/home/_home.json.jbuilder
+++ b/app/views/home/_home.json.jbuilder
@@ -12,6 +12,7 @@ json.stories stories do |story|
     json.name speaker.name
     json.picture_url speaker.picture_url
   end
+  json.permission_level story.permission_level == "anonymous" ? "anonymous" : "restricted"
 end
 json.logo_path image_path("logocombo.svg")
 json.user current_user


### PR DESCRIPTION
- I chose to combine user_only and editor_only permission_levels into
one "restricted" value since the UI doesn't care about the difference
between the two at the moment. 
I can change this to all 3 values of the enum if we think it's a good idea

- I also briefly tried using the font-awesome lock instead of the emoji, but couldn't figure out how to get it to render...

Looks like there are 2 issues for this?
https://github.com/Terrastories/terrastories/issues/168
https://github.com/Terrastories/terrastories/issues/266

Screenshot of what the change looks like:
<img width="399" alt="Screen Shot 2019-10-31 at 3 43 55 AM" src="https://user-images.githubusercontent.com/217050/67941454-dd69b480-fb92-11e9-89d9-a249f0bf3c75.png">
