### PR TITLE
[#372] - Remove manifest.json as it should be generated during deployment.

### DIFF
--- a/public/packs/manifest.json
+++ b/public/packs/manifest.json
@@ -1,8 +1,0 @@
-{
-  "application.js": "/packs/application-8688ef00ef526b0b38a8.js",
-  "application.js.map": "/packs/application-8688ef00ef526b0b38a8.js.map",
-  "hello_react.js": "/packs/hello_react-92059456b735f947ccc3.js",
-  "hello_react.js.map": "/packs/hello_react-92059456b735f947ccc3.js.map",
-  "server_rendering.js": "/packs/server_rendering-6fa063a87b34fda4a22a.js",
-  "server_rendering.js.map": "/packs/server_rendering-6fa063a87b34fda4a22a.js.map"
-}


### PR DESCRIPTION
Fixes #372 

Now when starting up it compiles the assets on the first request:

```
web_1  | Started GET "/" for 172.20.0.1 at 2019-11-11 14:45:36 +0000
web_1  | Cannot render console from 172.20.0.1! Allowed networks: 127.0.0.1, ::1, 127.0.0.0/127.255.255.255
web_1  |    (0.8ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC
web_1  |   ↳ /usr/local/bundle/gems/activerecord-5.2.3/lib/active_record/log_subscriber.rb:98
web_1  | Processing by WelcomeController#index as HTML
web_1  |   Rendering welcome/index.html.erb within layouts/application
web_1  |   User Load (2.9ms)  SELECT  "users".* FROM "users" WHERE "users"."id" = $1 ORDER BY "users"."id" ASC LIMIT $2  [["id", 2], ["LIMIT", 1]]
web_1  |   ↳ app/views/welcome/index.html.erb:4
web_1  |   Rendered welcome/index.html.erb within layouts/application (13549.4ms)
web_1  | [Webpacker] Compiling…
web_1  | [Webpacker] Compiled all packs in /opt/terrastories/public/packs
web_1  | [Webpacker] Hash: 8540f849539db1f8c82e
web_1  | Version: webpack 3.12.0
web_1  | Time: 3469ms
web_1  |                                        Asset       Size  Chunks                    Chunk Names
web_1  |     server_rendering-f6146eadc0ec2fc3264b.js    2.27 MB       0  [emitted]  [big]  server_rendering
web_1  |          application-91ca333b7fa3fc47d67f.js    2.27 MB       1  [emitted]  [big]  application
web_1  | server_rendering-f6146eadc0ec2fc3264b.js.map    2.45 MB       0  [emitted]         server_rendering
web_1  |      application-91ca333b7fa3fc47d67f.js.map    2.45 MB       1  [emitted]         application
web_1  |                                manifest.json  302 bytes          [emitted]         
web_1  |   [50] (webpack)/buildin/global.js 509 bytes {0} {1} [built]
web_1  |  [119] ./app/javascript/components ^\.\/.*$ 402 bytes {0} {1} [built]
web_1  |  [123] ./app/javascript/vendor/mapboxgl-control-minimap.js 9.32 kB {0} {1} [built]
web_1  |  [249] ./app/javascript/constants/FilterConstants.js 94 bytes {0} {1} [built]
web_1  |  [264] ./app/javascript/packs/application.js 634 bytes {1} [built]
web_1  |  [265] ./app/javascript/packs/server_rendering.js 301 bytes {0} [built]
web_1  |     + 260 hidden modules
web_1  | 
web_1  | Completed 200 OK in 19380ms (Views: 19360.9ms | ActiveRecord: 11.6ms)

```