### PR TITLE
Revert "[#342] Setup 'bundler-audit' gem and fix vulnerabilities"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,7 +62,6 @@ group :development, :test do
   gem 'pry-rails'
   gem 'guard-rspec'
   gem 'shoulda-matchers'
-  gem 'bundler-audit'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,9 +80,6 @@ GEM
     bootsnap (1.4.5)
       msgpack (~> 1.0)
     builder (3.2.3)
-    bundler-audit (0.6.1)
-      bundler (>= 1.2.0, < 3)
-      thor (~> 0.18)
     byebug (11.0.1)
     capybara (3.29.0)
       addressable
@@ -288,7 +285,7 @@ GEM
       rspec-support (~> 3.8.0)
     rspec-support (3.8.2)
     ruby_dep (1.5.0)
-    rubyzip (1.3.0)
+    rubyzip (1.2.4)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -365,7 +362,6 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   bootsnap (>= 1.1.0)
-  bundler-audit
   byebug
   capybara (>= 2.15, < 4.0)
   chromedriver-helper


### PR DESCRIPTION
Reverts Terrastories/terrastories#363 

I merged this PR without checking it locally because it had already been approved (..oops), but it seems like it is causing the terrastories_web_1 container to crash (I reverted to a previous commit locally and was able to run the container). It'd be best to revert this merge and then add the fix to the original PR 