### PR TITLE
Revert "Revert "[#342] Setup 'bundler-audit' gem and fix vulnerabilities""

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ group :development, :test do
   gem 'pry-rails'
   gem 'guard-rspec'
   gem 'shoulda-matchers'
+  gem 'bundler-audit'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,9 @@ GEM
     bootsnap (1.4.5)
       msgpack (~> 1.0)
     builder (3.2.3)
+    bundler-audit (0.6.1)
+      bundler (>= 1.2.0, < 3)
+      thor (~> 0.18)
     byebug (11.0.1)
     capybara (3.29.0)
       addressable
@@ -285,7 +288,7 @@ GEM
       rspec-support (~> 3.8.0)
     rspec-support (3.8.2)
     ruby_dep (1.5.0)
-    rubyzip (1.2.4)
+    rubyzip (1.3.0)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -362,6 +365,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   bootsnap (>= 1.1.0)
+  bundler-audit
   byebug
   capybara (>= 2.15, < 4.0)
   chromedriver-helper


### PR DESCRIPTION
Reverts Terrastories/terrastories#386 && Reopens original PR #342 

It looks like the build on Heroku succeeded so I will test this change locally and see if I can reproduce the issue that @MxOliver was having.