### PR TITLE
Adding postgres volume

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -14,11 +14,13 @@ This instructions are for Mapbox Community Days and Hacktoberfest, which everyon
 
 5. [Development](#development)
 
-6. [Importing data into Terrastories](#importing-data-into-terrastories)
+6. [Backup and Restore Postgres Database](#backup-and-restore-postgres-database)
 
-7. [Adding languages to Terrastories](#adding-languages-to-terrastories)
+7. [Importing data into Terrastories](#importing-data-into-terrastories)
 
-8. [Setting up your Development Environment](#setting-up-your-development-environment)
+8. [Adding languages to Terrastories](#adding-languages-to-terrastories)
+
+9. [Setting up your Development Environment](#setting-up-your-development-environment)
 
 ## Docker Prerequisites
 
@@ -105,6 +107,21 @@ environment. Always use the rails container instead.**
 
 Any changes to source files should be made directly in your local filesystem under the
 `/rails` directory using your preferred editing tools.
+
+## Backup and Restore Postgres Database
+
+Backup the DB with:
+
+```
+docker run --rm -v "terrastories_postgres_data:/pgdata" busybox tar -cvzf - -C /pgdata . >db-backup.tgz 
+```
+
+Restore a backup with:
+
+```
+docker volume rm terrastories_postgres_data
+docker run --rm -i -v "terrastories_postgres_data:/pgdata" busybox tar -xvzf - -C /pgdata <db-backup.tgz
+```
 
 ## Importing data into Terrastories
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -14,7 +14,7 @@ This instructions are for Mapbox Community Days and Hacktoberfest, which everyon
 
 5. [Development](#development)
 
-6. [Backup and Restore Postgres Database](#backup-and-restore-postgres-database)
+6. [Backup and restore the Terrastories database](#backup-and-restore-the-terrastories-database)
 
 7. [Importing data into Terrastories](#importing-data-into-terrastories)
 
@@ -108,7 +108,9 @@ environment. Always use the rails container instead.**
 Any changes to source files should be made directly in your local filesystem under the
 `/rails` directory using your preferred editing tools.
 
-## Backup and Restore Postgres Database
+## Backup and restore the Terrastories database
+
+Terrastories stores Places, Speakers, and Stories in a database (Postgres DB). it is possible to back these data up and restore them by running lines of code in a bash terminal.
 
 Backup the DB with:
 
@@ -122,6 +124,22 @@ Restore a backup with:
 docker volume rm terrastories_postgres_data
 docker run --rm -i -v "terrastories_postgres_data:/pgdata" busybox tar -xvzf - -C /pgdata <db-backup.tgz
 ```
+
+**For Windows** applications like PowerShell (PS), a slightly different syntax is needed. 
+
+Backup the DB in PS with:
+
+```
+docker run --rm -v "terrastories_postgres_data:/pgdata" -v "$(pwd):/host" busybox tar -cvzf /host/db-backup-test.tgz -C //pgdata .
+```
+
+Restore a backup in PS with:
+
+```
+docker run --rm -i -v "terrastories_postgres_data:/pgdata" -v "$(pwd):/source/" busybox tar -xvzf /source/db-backup.tgz -C /pgdata
+```
+
+Note: the above code is assuming your build is called `terrastories`. It may be necessary to run `docker volume ls` to get the right Docker container name ending with `_postgres_data`.
 
 ## Importing data into Terrastories
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -130,7 +130,7 @@ docker run --rm -i -v "terrastories_postgres_data:/pgdata" busybox tar -xvzf - -
 Backup the DB in PS with:
 
 ```
-docker run --rm -v "terrastories_postgres_data:/pgdata" -v "$(pwd):/host" busybox tar -cvzf /host/db-backup-test.tgz -C //pgdata .
+docker run --rm -v "terrastories_postgres_data:/pgdata" -v "$(pwd):/host" busybox tar -cvzf /host/db-backup-test.tgz -C /pgdata .
 ```
 
 Restore a backup in PS with:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
       - 5432:5432
     environment:
       POSTGRES_PASSWORD: ${DB_USER_PASSWORD}
+    volumes:
+      - "postgres_data:/var/lib/postgresql/data"
 
   # webpacker:
   #   image: ${DOCKER_IMAGE_NAME-terrastories}
@@ -30,3 +32,7 @@ services:
     command: ["./scripts/wait-for-it.sh", "db:5432", "--", "./scripts/start_rails.sh"]
     volumes:
       - .:/opt/terrastories:cached
+
+volumes:
+  postgres_data:
+


### PR DESCRIPTION
Fixes #388
Used a named volume to avoid permission issues from host volumes.
Steps to backup/restore a postgres DB are included in the SETUP.md.