### PR TITLE
Update Map.jsx with padding for fitBounds

### DIFF
--- a/app/javascript/components/Map.jsx
+++ b/app/javascript/components/Map.jsx
@@ -80,7 +80,7 @@ export default class Map extends Component {
     ) {
       const { bounds, ...frameOptions } = this.props.framedView;
       if (bounds) {
-        this.map.fitBounds(bounds, { duration: 2000.0, ...frameOptions });
+        this.map.fitBounds(bounds, { padding: 50, duration: 2000.0, ...frameOptions });
       } else {
         this.map.easeTo({ duration: 2000.0, ...frameOptions });
       }


### PR DESCRIPTION
Addresses https://github.com/Terrastories/terrastories/issues/408.

Found the padding parameter in the Mapbox GL JS documentation and applied it. 50 pixels seems like an appropriate distance. I tried other pixel sizes to confirm that it's adjusting appropriately; it is.

![image](https://user-images.githubusercontent.com/31662219/78709155-34fa1200-78e1-11ea-81f5-fb759201f651.png)
