### PR TITLE
Update Map.jsx removing resetMapToCenter()

### DIFF
--- a/app/javascript/components/Map.jsx
+++ b/app/javascript/components/Map.jsx
@@ -85,10 +85,6 @@ export default class Map extends Component {
         this.map.easeTo({ duration: 2000.0, ...frameOptions });
       }
       return;
-    } else {
-      if (this.map) {
-        this.resetMapToCenter();
-      }
     }
   }
 


### PR DESCRIPTION
This PR simultaneously addresses https://github.com/Terrastories/terrastories/issues/259 and https://github.com/Terrastories/terrastories/issues/423

...by removing the `resetMapToCenter()` behavior from the app altogether, with the exception of the Home button. 

This is a UI design decision targeting minimizing the amount of `Moving Around` as a whole.