### PR TITLE
FIX: Render photos for Speakers and Places in the Administrate back end

### DIFF
--- a/rails/Dockerfile
+++ b/rails/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get -y update && \
   git-all \
   curl \
   ssh \
+  imagemagick \
   postgresql-client-11 libpq5 libpq-dev -y && \
   wget -qO- https://deb.nodesource.com/setup_12.x  | bash - && \
   apt-get install -y nodejs && \

--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -44,7 +44,7 @@ gem 'font-awesome-rails', '~> 4.7'
 gem 'plyr-rails'
 
 # Use ActiveStorage variant
-# gem 'mini_magick', '~> 4.8'
+gem 'mini_magick', '~> 4.8'
 
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development

--- a/rails/Gemfile.lock
+++ b/rails/Gemfile.lock
@@ -186,6 +186,7 @@ GEM
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
     mimemagic (0.3.3)
+    mini_magick (4.10.1)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     mini_racer (0.2.6)
@@ -379,6 +380,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   mapbox-gl-rails
+  mini_magick (~> 4.8)
   mini_racer
   pg (>= 0.18, < 2.0)
   plyr-rails


### PR DESCRIPTION
This PR fixes https://github.com/Terrastories/terrastories/issues/407.
BUG: Administrate gem was not able to render images from `active_storage`
FIX: Add gem `mini_magick`, and install dependencies into docker container