### PR TITLE
Update Map.jsx with padding for fitBounds

### DIFF
--- a/rails/app/javascript/components/Map.jsx
+++ b/rails/app/javascript/components/Map.jsx
@@ -80,7 +80,7 @@ export default class Map extends Component {
     ) {
       const { bounds, ...frameOptions } = this.props.framedView;
       if (bounds) {
-        this.map.fitBounds(bounds, { duration: 2000.0, ...frameOptions });
+        this.map.fitBounds(bounds, { padding: 50, duration: 2000.0, ...frameOptions });
       } else {
         this.map.easeTo({ duration: 2000.0, ...frameOptions });
       }


### PR DESCRIPTION
Addresses #408.

Found the padding parameter in the Mapbox GL JS documentation and applied it. 50 pixels seems like an appropriate distance. I tried other pixel sizes to confirm that it's adjusting appropriately; it is.

![image](https://user-images.githubusercontent.com/31662219/79790539-dccc0280-8319-11ea-9254-8ad83b976ae3.png)
