### PR TITLE
446 translating selected phrase

### DIFF
--- a/rails/app/helpers/application_helper.rb
+++ b/rails/app/helpers/application_helper.rb
@@ -1,7 +1,7 @@
 module ApplicationHelper
   def application_locales
     locales = I18n.available_locales.sort.map do |locale|
-      locale_identifier = locale == I18n.locale ? "#{locale} #{t("selected_language")} " : locale
+      locale_identifier = locale == I18n.locale ? "#{locale} (#{t("selected_language")}) " : locale
       link_to locale_identifier, root_path(locale: locale), class: "language-color"
     end
     safe_join(locales, " | ".html_safe)

--- a/rails/config/locales/en/en.yml
+++ b/rails/config/locales/en/en.yml
@@ -24,7 +24,7 @@ en:
   remember_me: "Remember me"
   reversed_alphabetical: Z-A
   select_category: "Select category"
-  selected_language: "(selected)"
+  selected_language: "selected"
   select_option: "Select option"
   sign_up: "Sign up"
   sort_stories: "Sort stories"

--- a/rails/config/locales/es/es.yml
+++ b/rails/config/locales/es/es.yml
@@ -24,7 +24,7 @@ es:
   remember_me: "Recordarme"
   reversed_alphabetical: Z-A
   select_category: "Seleccionar categoría"
-  selected_language: "(seleccionado)"
+  selected_language: "seleccionado"
   select_option: "Seleccionar opción"
   sign_up: "Registrarse"
   sort_stories: "Ordenar las historias"

--- a/rails/config/locales/ja/ja.yml
+++ b/rails/config/locales/ja/ja.yml
@@ -24,7 +24,7 @@ ja:
   remember_me: "パスワードを保存"
   reversed_alphabetical: Z-A
   select_category: "カテゴリを選択"
-  selected_language: "(選択した)"
+  selected_language: "選択した"
   select_option: "オプションを選択"
   sign_up: "サインアップ"
   sort_stories: "並べ替え"

--- a/rails/config/locales/mat/mat.yml
+++ b/rails/config/locales/mat/mat.yml
@@ -23,7 +23,7 @@ mat:
   filter_stories: "Luku fini"
   select_category: "Kies wan sooti sondi"
   place_type: "Sooti kamia"
-  selected_language: "(a tongo aki)"
+  selected_language: "a tongo aki"
   select_option: "Kies a sondi"
   sort_stories: "Koowa di toli"
   most_recent: "Moo nyu"

--- a/rails/config/locales/mat/mat.yml
+++ b/rails/config/locales/mat/mat.yml
@@ -23,7 +23,7 @@ mat:
   filter_stories: "Luku fini"
   select_category: "Kies wan sooti sondi"
   place_type: "Sooti kamia"
-  selected_language: "(selected)"
+  selected_language: "(a tongo aki)"
   select_option: "Kies a sondi"
   sort_stories: "Koowa di toli"
   most_recent: "Moo nyu"

--- a/rails/config/locales/nl/nl.yml
+++ b/rails/config/locales/nl/nl.yml
@@ -26,7 +26,7 @@ nl:
   forgot_password: "Paswoord vergeten?"
   filter_stories: "Verhalen filteren"
   select_category: "Kies een categorie"
-  selected_language: "(selected)"
+  selected_language: "(geselecteerde)"
   place_type: "Soort plek"
   select_option: "Selecteer optie"
   region: "Regio"

--- a/rails/config/locales/nl/nl.yml
+++ b/rails/config/locales/nl/nl.yml
@@ -26,7 +26,7 @@ nl:
   forgot_password: "Paswoord vergeten?"
   filter_stories: "Verhalen filteren"
   select_category: "Kies een categorie"
-  selected_language: "(geselecteerde)"
+  selected_language: "geselecteerde"
   place_type: "Soort plek"
   select_option: "Selecteer optie"
   region: "Regio"

--- a/rails/config/locales/pt/pt.yml
+++ b/rails/config/locales/pt/pt.yml
@@ -23,7 +23,7 @@ pt:
   filter_stories: "Filtrar histórias"
   select_category: "Escolher categoria"
   place_type: "Tipo de lugar"
-  selected_language: "(selected)"
+  selected_language: "(selecionado)"
   select_option: "Escolher a opção"
   sort_stories: "Classificar histórias"
   most_recent: "Mais recente"

--- a/rails/config/locales/pt/pt.yml
+++ b/rails/config/locales/pt/pt.yml
@@ -23,7 +23,7 @@ pt:
   filter_stories: "Filtrar histórias"
   select_category: "Escolher categoria"
   place_type: "Tipo de lugar"
-  selected_language: "(selecionado)"
+  selected_language: "selecionado"
   select_option: "Escolher a opção"
   sort_stories: "Classificar histórias"
   most_recent: "Mais recente"


### PR DESCRIPTION
This is a supplementary PR for https://github.com/Terrastories/terrastories/issues/446 that adds translation for `selected` in Matawai, Dutch, and Portuguese, and codes the parentheses into the helper file (rather than having them be in the i18n files).