### PR TITLE
Pop-up image update

### DIFF
--- a/rails/app/assets/stylesheets/components/_balloon.scss
+++ b/rails/app/assets/stylesheets/components/_balloon.scss
@@ -1,19 +1,17 @@
 .ts-markerPopup {
   &-content {
-    display: flex;
     justify-content: center;
     padding: 0.5rem;
     color: $default-text;
 
     img {
-      width: 100px;
-      height: 100px;
+      width: 100%;
+      height: auto;
     }
   }
 
   .mapboxgl-popup-content {
     h1, h2, h3, h4, h5, p, img {
-      padding: 0.5rem;
       margin: 0;
     }
     padding: 0rem;

--- a/rails/app/assets/stylesheets/components/_balloon.scss
+++ b/rails/app/assets/stylesheets/components/_balloon.scss
@@ -1,6 +1,5 @@
 .ts-markerPopup {
   &-content {
-    justify-content: center;
     padding: 0.5rem;
     color: $default-text;
 


### PR DESCRIPTION
This fixes issue #469. These are the pop-ups before: 
<img width="253" alt="Screen Shot 2020-07-13 at 1 23 15 PM" src="https://user-images.githubusercontent.com/46689344/87384983-e9937780-c551-11ea-9c14-cb47bcd28dea.png">
<img width="258" alt="Screen Shot 2020-07-13 at 1 23 02 PM" src="https://user-images.githubusercontent.com/46689344/87384988-eef0c200-c551-11ea-85da-447ff9c078f2.png">

After Changes:
<img width="268" alt="Screen Shot 2020-07-13 at 1 22 25 PM" src="https://user-images.githubusercontent.com/46689344/87385011-fc0db100-c551-11ea-98d3-8efea61dc0f2.png">
<img width="274" alt="Screen Shot 2020-07-13 at 1 22 19 PM" src="https://user-images.githubusercontent.com/46689344/87385021-ff08a180-c551-11ea-8407-749808057a14.png">


All images are in their original proportions, the container expands with the picture. 

