### PR TITLE
Fix rspec tests such that all tests run and pass

### DIFF
--- a/rails/app/controllers/stories_controller.rb
+++ b/rails/app/controllers/stories_controller.rb
@@ -48,7 +48,7 @@ class StoriesController < ApplicationController
   private
 
   def story_params
-    params.require(:story).permit(:title, :desc, :point_id, :interview_location_id, :interviewer_id, speakers: [], media: [])
+    params.require(:story).permit(:title, :desc, :point_id, :permission_level, :interview_location_id, :interviewer_id, speaker_ids: [], speakers: [], media: [])
   end
 
   def remove_attachment

--- a/rails/app/models/place.rb
+++ b/rails/app/models/place.rb
@@ -5,8 +5,8 @@ class Place < ApplicationRecord
   has_and_belongs_to_many :stories
   has_one_attached :photo
   validate :photo_format
-  validates :lat, numericality: { greater_than_or_equal_to:  -90, less_than_or_equal_to:  90 }
-  validates :long, numericality: { greater_than_or_equal_to: -180, less_than_or_equal_to: 180 }
+  validates :lat, numericality: { greater_than_or_equal_to:  -90, less_than_or_equal_to:  90 }, allow_blank: true
+  validates :long, numericality: { greater_than_or_equal_to: -180, less_than_or_equal_to: 180 }, allow_blank: true
   has_many :interview_stories, class_name: "Story", foreign_key: "interview_location_id"
 
   attr_reader :point_geojson

--- a/rails/app/models/story.rb
+++ b/rails/app/models/story.rb
@@ -8,7 +8,7 @@ class Story < ApplicationRecord
   belongs_to :interview_location, class_name: "Place", foreign_key: "interview_location_id", optional: true
   belongs_to :interviewer, class_name: "Speaker", foreign_key: "interviewer_id", optional: true
 
-  validates_presence_of :speaker_stories, message: ': Your story must have at least one Speaker'
+  validates_presence_of :speakers, message: ': Your story must have at least one Speaker'
 
   def self.import_csv(file_contents)
     CSV.parse(file_contents, headers: true) do |row|

--- a/rails/spec/controllers/stories_controller_spec.rb
+++ b/rails/spec/controllers/stories_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe StoriesController, type: :controller do
   before :each do
     @rfg2018 = create(:place)
     @miranda = create(:speaker)
-    @rudo_story = create(:story)
+    @rudo_story = create(:story, :with_speakers)
   end
 
   describe "GET index" do
@@ -41,8 +41,10 @@ RSpec.describe StoriesController, type: :controller do
              story: {
                title: "Story title",
                desc: "Story description",
+               permission_level: "anonymous",
                interview_location_id: @rfg2018,
-               interviewer_id: @miranda
+               interviewer_id: @miranda,
+               speaker_ids: [ @miranda ]
              }
            }
     }

--- a/rails/spec/models/curriculum_spec.rb
+++ b/rails/spec/models/curriculum_spec.rb
@@ -1,5 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Curriculum, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'associations' do
+    it { should belong_to :user}
+    it { should have_many :curriculum_stories}
+    it { should have_many :stories }
+  end
 end

--- a/rails/spec/models/place_spec.rb
+++ b/rails/spec/models/place_spec.rb
@@ -11,68 +11,77 @@ RSpec.describe Place, type: :model do
       expect(file_fixture('place_with_media.csv').read).not_to be_empty
     end
 
-    it 'imports csv with media' do
-      fixture_data = file_fixture('place_with_media.csv').read
-      described_class.import_csv(fixture_data)
+    describe 'imports csv with media' do
+      before do
+        @fixture_data = file_fixture('place_with_media.csv').read
+        described_class.import_csv(@fixture_data)
+      end
 
-      place = described_class.first
-      csv = CSV.parse(fixture_data, headers: true).first
+      let!(:place) { described_class.last }
+      let!(:csv) { CSV.parse(@fixture_data, headers: true).first }
 
-      expect(place.name).to eq csv[0]
-      expect(place.type_of_place).to eq csv[1]
-      expect(place.description).to eq csv[2]
-      expect(place.region).to eq csv[3]
-      expect(place.long).to eq csv[4].to_f
-      expect(place.lat).to eq csv[5].to_f
-      expect(place.photo.filename.to_s).to eq csv[6]
+      it { expect(place.name).to eq csv[0] }
+      it { expect(place.type_of_place).to eq csv[1] }
+      it { expect(place.description).to eq csv[2] }
+      it { expect(place.region).to eq csv[3] }
+      it { expect(place.long).to eq csv[4].to_f }
+      it { expect(place.lat).to eq csv[5].to_f }
+      it { expect(place.photo.filename.to_s).to eq csv[6] }
     end
 
-    it 'does not fail when media is not present' do
-      fixture_data = file_fixture('place_without_media.csv').read
-      described_class.import_csv(fixture_data)
+    describe 'does not fail when media is not present' do
+      before do
+        @fixture_data = file_fixture('place_without_media.csv').read
+        described_class.import_csv(@fixture_data)
+      end
 
-      place = described_class.first
-      csv = CSV.parse(fixture_data, headers: true).first
-      expect(csv[6]).not_to be_nil
+      let!(:place) { described_class.last }
+      let!(:csv) { CSV.parse(@fixture_data, headers: true).first }
+      it { expect(csv[6]).not_to be_nil }
     end
   end
 
   describe '#photo_format' do
     context 'when the attachment is not located in an image folder' do
-      it 'should add an error' do
-        fixture_data = file_fixture('place_with_media.csv').read
-        described_class.import_csv(fixture_data)
-        place = described_class.first
-        place.photo.blob.content_type = "file/png"
-        place.photo_format
+      describe 'should add an error' do
+        before do
+          @fixture_data = file_fixture('place_with_media.csv').read
+          described_class.import_csv(@fixture_data)
+          @place = described_class.last
+          @place.photo.blob.content_type = "file/png"
+          @place.photo_format
+        end
 
-        expect(place.photo.blob.content_type.start_with?('image/')).to be(false)
-        expect(place.errors.count).to eq(1)
+        it { expect(@place.photo.blob.content_type.start_with?('image/')).to be(false) }
+        it { expect(@place.errors.count).to eq(1) }
       end
     end
 
     context 'when the attachment is located in an image folder' do
-      it 'should not add an error' do
-        fixture_data = file_fixture('place_with_media.csv').read
-        described_class.import_csv(fixture_data)
-        place = described_class.first
-        place.photo_format
+      describe 'should not add an error' do
+        before do
+          @fixture_data = file_fixture('place_with_media.csv').read
+          described_class.import_csv(@fixture_data)
+        end
+        let!(:place) { described_class.last }
 
-        expect(place.photo.blob.content_type.start_with?('image/')).to be(true)
-        expect(place.errors.count).to eq(0)
+        it { expect(place.photo.blob.content_type.start_with?('image/')).to be(true) }
+        it { expect(place.errors.count).to eq(0) }
       end
     end
   end
 
   describe 'photo_url' do
-    it 'should return a url path' do
-      fixture_data = file_fixture('place_with_media.csv').read
-      described_class.import_csv(fixture_data)
-      place = described_class.first
-      file_name = place.photo.filename.to_s
+    describe 'should return a url path' do
+      before do
+        @fixture_data = file_fixture('place_with_media.csv').read
+        described_class.import_csv(@fixture_data)
+      end
+      let!(:place) { described_class.last }
+      let!(:file_name) { place.photo.filename.to_s }
 
-      expect(place.photo_url).to be_truthy
-      expect(place.photo_url.include?(file_name)).to be(true)
+      it { expect(place.photo_url).to be_truthy }
+      it { expect(place.photo_url.include?(file_name)).to be(true) }
     end
   end
 

--- a/rails/spec/models/speaker_spec.rb
+++ b/rails/spec/models/speaker_spec.rb
@@ -9,6 +9,4 @@ RSpec.describe Speaker, type: :model do
       expect(speaker).to have_attributes(name: "Oliver Twist", birthdate: DateTime.new(1992))
     end
   end
-
-
 end

--- a/rails/spec/models/story_spec.rb
+++ b/rails/spec/models/story_spec.rb
@@ -5,8 +5,6 @@ RSpec.describe Story, type: :model do
     it { should have_many :speaker_stories }
     it { should have_many :speakers }
     it { should have_and_belong_to_many :places }
-
-    # Issue 406 requested that interviewer and interview location be made optional for story creation
     it { should belong_to(:interview_location).optional }
     it { should belong_to(:interviewer).optional }
   end
@@ -31,8 +29,6 @@ RSpec.describe Story, type: :model do
         described_class.import_csv(@fixture_data)
       end
       let!(:story) {described_class.last}
-      # puts story.title
-      # puts story.desc
       let!(:csv) {CSV.parse(@fixture_data, headers: true).first}
 
 

--- a/rails/spec/models/story_spec.rb
+++ b/rails/spec/models/story_spec.rb
@@ -14,45 +14,51 @@ RSpec.describe Story, type: :model do
   describe 'validation' do
     let(:story_1) {build(:story)}
     let(:story_2) {create(:story, :with_speakers)}
-    it 'must have at least one speaker' do
-      expect(story_1).to_not be_valid
-      expect(story_2).to be_valid
+    describe 'must have at least one speaker' do
+      it {expect(story_1).to_not be_valid}
+      it {expect(story_2).to be_valid}
     end
   end
 
-  describe '.import_csv' do
-    it 'is tested against fixture file' do
-      expect(file_fixture('story_with_media.csv').read).not_to be_empty
+  context '.import_csv' do
+    describe 'is tested against fixture file' do
+      it {expect(file_fixture('story_with_media.csv').read).not_to be_empty}
     end
 
-    it 'delegates all attributes to decorator' do
-      fixture_data = file_fixture('story_with_media.csv').read
-      described_class.import_csv(fixture_data)
+    describe 'delegates all attributes to decorator' do
+      before(:all) do
+        @fixture_data = file_fixture('story_with_media.csv').read
+        described_class.import_csv(@fixture_data)
+      end
+      let!(:story) {described_class.last}
+      # puts story.title
+      # puts story.desc
+      let!(:csv) {CSV.parse(@fixture_data, headers: true).first}
 
-      story = described_class.last
-      csv = CSV.parse(fixture_data, headers: true).first
 
-      expect(story.title).to eq csv[0]
-      expect(story.desc).to eq csv[1]
-      expect(story.speakers.map(&:name).join(',')).to eq csv[2]
-      expect(story.places.map(&:name).join(',')).to eq csv[3]
-      expect(story.interview_location.name).to eq csv[4]
-      expect(story.date_interviewed.strftime('%m/%d/%y')).to eq csv[5]
-      expect(story.interviewer.name).to eq csv[6].strip
-      expect(story.language).to eq csv[7]
-      expect(story.permission_level).to eq "anonymous"
-      expect(story.media.first.filename.to_s).to eq csv[8]
+      it { expect(story.title).to eq csv[0] }
+      it { expect(story.desc).to eq csv[1] }
+      it { expect(story.speakers.map(&:name).join(',')).to eq csv[2] }
+      it { expect(story.places.map(&:name).join(',')).to eq csv[3] }
+      it { expect(story.interview_location.name).to eq csv[4] }
+      it { expect(story.date_interviewed.strftime('%m/%d/%y')).to eq csv[5] }
+      it { expect(story.interviewer.name).to eq csv[6].strip }
+      it { expect(story.language).to eq csv[7] }
+      it { expect(story.permission_level).to eq "anonymous" }
+      it { expect(story.media.first.filename.to_s).to eq csv[8] }
     end
 
-    it 'does not fail when media is not present' do
-      fixture_data = file_fixture('story_without_media.csv').read
-      described_class.import_csv(fixture_data)
+    describe 'does not fail when media is not present' do
+      before do
+        @fixture_data = file_fixture('story_without_media.csv').read
+        described_class.import_csv(@fixture_data)
 
-      story = described_class.last
-      csv = CSV.parse(fixture_data, headers: true).first
+      end
+      let!(:story) { described_class.last }
+      let!(:csv) { CSV.parse(@fixture_data, headers: true).first }
 
-      expect(story.media.all.count).to eq 0
-      expect(csv[8]).not_to be_nil
+      it {expect(story.media.all.count).to eq 0}
+      it {expect(csv[8]).not_to be_nil}
     end
   end
 end

--- a/rails/spec/requests/stories_spec.rb
+++ b/rails/spec/requests/stories_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Stories", type: :request do
   before :each do
     @rfg2018 = create(:place)
     @miranda = create(:speaker)
-    @rudo_story = create(:story)
+    @rudo_story = create(:story, :with_speakers)
   end
 
   describe "GET edit" do
@@ -48,7 +48,8 @@ RSpec.describe "Stories", type: :request do
           title: "Story title",
           desc: "Story description",
           interview_location_id: create(:place).id,
-          interviewer_id: create(:speaker).id
+          interviewer_id: create(:speaker).id,
+          speaker_ids: [ create(:speaker).id ]
         }
       }
 


### PR DESCRIPTION
- Addresses issue #461 
- Corrects syntax in several files so that there is only one expect statement per 'it' block
- Adds speakers to all necessary Story parameter objects
- Makes lat & long optional for Place creation
- Adds basic association tests for the Curriculum model