### PR TITLE
Fix media import

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,8 +25,6 @@ services:
         precompileassets: "not"
     env_file:
       - .env
-    volumes:
-      - ./rails:/opt/terrastories:cached
 
   web:
     <<: *x-web-common
@@ -36,6 +34,7 @@ services:
     depends_on:
       - db
     volumes:
+      - ./rails:/opt/terrastories:cached
       - ./data/media:/media
       - ./data/import/media:/opt/terrastories/import/media
 
@@ -48,6 +47,8 @@ services:
       - 3001:3000
     depends_on:
       - db
+    volumes:
+      - ./rails:/opt/terrastories:cached
 
   selenium:
     # Debug version enables VNC ability

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       - db
     volumes:
       - ./data/media:/media
+      - ./data/import/media:/opt/terrastories/import/media
 
   web-test:
     <<: *x-web-common

--- a/rails/app/models/place.rb
+++ b/rails/app/models/place.rb
@@ -1,5 +1,5 @@
 class Place < ApplicationRecord
-  MEDIA_PATH = Rails.env.test? ? 'spec/fixtures/media' : 'media'
+  MEDIA_PATH = Rails.env.test? ? 'spec/fixtures/media' : 'import/media'
 
   require 'csv'
   has_and_belongs_to_many :stories

--- a/rails/app/models/speaker.rb
+++ b/rails/app/models/speaker.rb
@@ -1,7 +1,7 @@
 # == Schema Information ==
 #
 # Table name: speakers
-# 
+#
 # id          ... not null primary key
 # speaker_name... string
 # birth_year  ... datetime, nil if blank
@@ -33,7 +33,7 @@ class Speaker < ApplicationRecord
       speaker.birthplace = get_birthplace(row[2])
       # Assumes birth date field is always just a year
       speaker.birthdate = row[1].nil? || row[1].downcase == 'unknown' ? nil : Date.strptime(row[1], "%Y")
-      if row[3] && File.exist?(Rails.root.join('media', row[3]))
+      if row[3] && File.exist?(Rails.root.join('import/media', row[3]))
         file = File.open(Rails.root.join('media',row[3]))
         speaker.photo.attach(io: file, filename: row[3])
       end

--- a/rails/app/models/speaker.rb
+++ b/rails/app/models/speaker.rb
@@ -34,7 +34,7 @@ class Speaker < ApplicationRecord
       # Assumes birth date field is always just a year
       speaker.birthdate = row[1].nil? || row[1].downcase == 'unknown' ? nil : Date.strptime(row[1], "%Y")
       if row[3] && File.exist?(Rails.root.join('import/media', row[3]))
-        file = File.open(Rails.root.join('media',row[3]))
+        file = File.open(Rails.root.join('import/media',row[3]))
         speaker.photo.attach(io: file, filename: row[3])
       end
       speaker.save

--- a/rails/app/models/story.rb
+++ b/rails/app/models/story.rb
@@ -1,5 +1,5 @@
 class Story < ApplicationRecord
-  MEDIA_PATH = Rails.env.test? ? 'spec/fixtures/media' : 'media'
+  MEDIA_PATH = Rails.env.test? ? 'spec/fixtures/media' : 'import/media'
 
   has_many :speaker_stories, inverse_of: :story
   has_many :speakers, through: :speaker_stories


### PR DESCRIPTION
## What

Mounts an import/media directory into the Rails root via Docker Compose. This fixes the CSV import where media files were not attached.

## Why

With the changes to Rails being in a subdirectory and the media folder not being moved with it, the media portion of the import didn't properly attach media to the story/place.

## Changes

- Added `import/media` directory to the root `data` folder with git `.keep` file.
- Mapped this folder to mount at `/opt/terrastories` (rails root).
- Updated Place and Story MEDIA_PATH to be `import/media`

## Testing

When you pull down these changes, you'll need to rebuild the container in order to correctly reference the new mounted filesystem:

```
docker-compose build web
```

You may need to rerun yarn to generate the manifest file at this time:

```
docker-compose exec web yarn
```