### PR TITLE
Removing media links from the frontend Story List for now since we're not ready to display it yet

### DIFF
--- a/rails/app/javascript/components/StoryList.jsx
+++ b/rails/app/javascript/components/StoryList.jsx
@@ -113,28 +113,6 @@ class StoryList extends Component {
             {story.media &&
               story.media.map(file => <StoryMedia file={file} doBustCache={bustCache} key={story.media.id} />)}
           </div>
-          <div className="container">
-            <h6>
-              Media Links
-            </h6>
-            <ol>
-              {
-                story.media_links.map( function (media_link, linkNum) {
-                    return(
-                      <li>
-                        <h6>
-                          video {linkNum + 1}
-                        </h6>
-                        <iframe width="100%" height="auto" src={media_link.url} frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen>
-            
-                        </iframe>
-                      </li>
-                    )
-                  }
-                )
-              }
-            </ol>
-          </div>
         </li>
       </CellMeasurer>
     );


### PR DESCRIPTION
Removing the view of Media Links in the StoryList!

![Screen Shot 2020-08-28 at 1 25 07 PM](https://user-images.githubusercontent.com/8590508/91595722-003f3380-e932-11ea-986e-852d7442e4a3.png)
