### PR TITLE
#510 - Add Sort.jsx specs

### DIFF
--- a/rails/spec/javascript/components/Sort.spec.js
+++ b/rails/spec/javascript/components/Sort.spec.js
@@ -1,0 +1,67 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Sort from '../../../app/javascript/components/Sort';
+
+describe('Sort component', () => {
+  beforeEach(() => {
+    global.I18n = {
+      t: jest.fn(),
+    };
+  });
+
+  const corinneStory = {
+    created_at: '2020-10-03T11:13:23.037Z',
+    title: "Corinne's testimonial",
+  };
+
+  const rudoStory = {
+    created_at: '2020-10-01T11:13:23.013Z',
+    title: "Rudo's testimonial",
+  };
+
+  it('Displays correctly', () => {
+    const wrapper = shallow(<Sort stories={[corinneStory, rudoStory]} />);
+
+    expect(wrapper).toMatchSnapshot();
+
+    expect(global.I18n.t).toHaveBeenCalledWith('sort_stories');
+    expect(global.I18n.t).toHaveBeenCalledWith('most_recent');
+    expect(global.I18n.t).toHaveBeenCalledWith('alphabetical');
+    expect(global.I18n.t).toHaveBeenCalledWith('reversed_alphabetical');
+  });
+
+  it('Calls handleStoriesChanged on change with expected sort', () => {
+    const handleStoriesChanged = jest.fn();
+
+    const props = {
+      handleStoriesChanged,
+      stories: [corinneStory, rudoStory],
+    };
+    const wrapper = shallow(<Sort {...props} />);
+
+    // componentDidMount call
+    expect(handleStoriesChanged.mock.calls.length).toBe(1);
+    expect(handleStoriesChanged.mock.calls[0][0]).toEqual([
+      corinneStory,
+      rudoStory,
+    ]);
+
+    wrapper.find('.storiesSort').simulate('change', { value: 'alphabetical' });
+
+    expect(handleStoriesChanged.mock.calls.length).toBe(2);
+    expect(handleStoriesChanged.mock.calls[1][0]).toEqual([
+      corinneStory,
+      rudoStory,
+    ]);
+
+    wrapper
+      .find('.storiesSort')
+      .simulate('change', { value: 'reversed_alphabetical' });
+
+    expect(handleStoriesChanged.mock.calls.length).toBe(3);
+    expect(handleStoriesChanged.mock.calls[2][0]).toEqual([
+      rudoStory,
+      corinneStory,
+    ]);
+  });
+});

--- a/rails/spec/javascript/components/Sort.spec.js
+++ b/rails/spec/javascript/components/Sort.spec.js
@@ -19,15 +19,21 @@ describe('Sort component', () => {
     title: "Rudo's testimonial",
   };
 
+  const sortValues = [
+    'sort_stories',
+    'most_recent',
+    'alphabetical',
+    'reversed_alphabetical',
+  ];
+
   it('Displays correctly', () => {
     const wrapper = shallow(<Sort stories={[corinneStory, rudoStory]} />);
 
     expect(wrapper).toMatchSnapshot();
 
-    expect(global.I18n.t).toHaveBeenCalledWith('sort_stories');
-    expect(global.I18n.t).toHaveBeenCalledWith('most_recent');
-    expect(global.I18n.t).toHaveBeenCalledWith('alphabetical');
-    expect(global.I18n.t).toHaveBeenCalledWith('reversed_alphabetical');
+    sortValues.forEach((sortValue) => {
+      expect(global.I18n.t).toHaveBeenCalledWith(sortValue);
+    });
   });
 
   it('Calls handleStoriesChanged on change with expected sort', () => {

--- a/rails/spec/javascript/components/__snapshots__/Sort.spec.js.snap
+++ b/rails/spec/javascript/components/__snapshots__/Sort.spec.js.snap
@@ -1,0 +1,42 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Sort component Displays correctly 1`] = `
+<Fragment>
+  <span
+    className="card--nav-sort"
+  >
+    : 
+  </span>
+  <StateManager
+    className="storiesSort"
+    classNamePrefix="select"
+    defaultInputValue=""
+    defaultMenuIsOpen={false}
+    defaultValue={null}
+    name="sort-stories"
+    onChange={[Function]}
+    options={
+      Array [
+        Object {
+          "label": undefined,
+          "value": "most_recent",
+        },
+        Object {
+          "label": undefined,
+          "value": "alphabetical",
+        },
+        Object {
+          "label": undefined,
+          "value": "reversed_alphabetical",
+        },
+      ]
+    }
+    value={
+      Object {
+        "label": undefined,
+        "value": "most_recent",
+      }
+    }
+  />
+</Fragment>
+`;


### PR DESCRIPTION
## Description
This PR adds specs to `Sort` component, using snapshot testing and _naive_ unit testing for the sorting algorithm executed when the Select in changed.

Triggering changes over `Select` component is a little bit cumbersome but after some research I couldn't found a better way of doing it using `enzyme`, I'll be happy to update and improve anything from this PR.

Closes https://github.com/Terrastories/terrastories/issues/510

