### PR TITLE
Migrate from chromedriver-helper to webdrivers gem

### DIFF
--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -84,7 +84,7 @@ group :test do
   gem 'capybara', '>= 2.15', '< 4.0'
   gem 'selenium-webdriver'
   # Easy installation and use of chromedriver to run system tests with Chrome
-  gem 'chromedriver-helper'
+  gem 'webdrivers'
   # Factories for creating database entities for testing
   gem 'factory_bot_rails'
   gem 'simplecov', require: false

--- a/rails/Gemfile.lock
+++ b/rails/Gemfile.lock
@@ -63,8 +63,6 @@ GEM
     administrate-field-nested_has_many (1.3.0)
       administrate (> 0.8, < 1)
       cocoon (~> 1.2, >= 1.2.11)
-    archive-zip (0.12.0)
-      io-like (~> 0.3.0)
     arel (9.0.0)
     autoprefixer-rails (9.8.6.3)
       execjs
@@ -110,9 +108,6 @@ GEM
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
     childprocess (3.0.0)
-    chromedriver-helper (2.1.1)
-      archive-zip (~> 0.10)
-      nokogiri (~> 1.8)
     cocoon (1.2.14)
     coderay (1.1.3)
     concurrent-ruby (1.1.7)
@@ -166,7 +161,6 @@ GEM
       concurrent-ruby (~> 1.0)
     i18n-js (3.7.1)
       i18n (>= 0.6.6)
-    io-like (0.3.1)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
     jmespath (1.4.0)
@@ -361,6 +355,10 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webdrivers (4.4.1)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     webpacker (3.6.0)
       activesupport (>= 4.2)
       rack-proxy (>= 0.6.1)
@@ -385,7 +383,6 @@ DEPENDENCIES
   bundler-audit
   byebug
   capybara (>= 2.15, < 4.0)
-  chromedriver-helper
   devise
   devise-i18n
   dotenv-rails
@@ -418,6 +415,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
+  webdrivers
   webpacker (~> 3.5)
 
 RUBY VERSION


### PR DESCRIPTION
## Description
This PR replaces `chromedriver-helper` with `webdrivers` gem since `chromedriver-helper` has been deprecated since 2019-03-31 ([source](https://github.com/flavorjones/chromedriver-helper) and now `webdrivers` is the recommended way of installing the webdrivers.

Checking the created Rails specs it doesn't seem there any of them using the `chromedriver` but this will avoid the deprecation warning when installing all the dependencies when setting up the project.