### PR TITLE
#539 Ensure that duplicate Places cannot be added using the importer

### DIFF
--- a/rails/spec/models/place_spec.rb
+++ b/rails/spec/models/place_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Place, type: :model do
     end
 
     describe "does not create duplicated places" do
-      it "creates a single place for same file twice" do
+      it "creates a single place when importing the same csv twice" do
         @fixture_data = file_fixture('place_with_media.csv').read
 
         expect {

--- a/rails/spec/models/place_spec.rb
+++ b/rails/spec/models/place_spec.rb
@@ -11,6 +11,22 @@ RSpec.describe Place, type: :model do
       expect(file_fixture('place_with_media.csv').read).not_to be_empty
     end
 
+    describe "does not create same places multiple times" do
+      it "creates a single place" do
+        header, place = file_fixture('place_with_media.csv').read.split("\n")
+
+        @fixture_data = [
+          header,
+          place,
+          place,
+        ].join("\n")
+
+        expect {
+          described_class.import_csv(@fixture_data)
+        }.to change { Place.count }.by(1)
+      end
+    end
+
     describe 'imports csv with media' do
       before do
         @fixture_data = file_fixture('place_with_media.csv').read

--- a/rails/spec/models/place_spec.rb
+++ b/rails/spec/models/place_spec.rb
@@ -11,19 +11,17 @@ RSpec.describe Place, type: :model do
       expect(file_fixture('place_with_media.csv').read).not_to be_empty
     end
 
-    describe "does not create same places multiple times" do
-      it "creates a single place" do
-        header, place = file_fixture('place_with_media.csv').read.split("\n")
-
-        @fixture_data = [
-          header,
-          place,
-          place,
-        ].join("\n")
+    describe "does not create duplicated places" do
+      it "creates a single place for same file twice" do
+        @fixture_data = file_fixture('place_with_media.csv').read
 
         expect {
           described_class.import_csv(@fixture_data)
         }.to change { Place.count }.by(1)
+
+        expect {
+          described_class.import_csv(@fixture_data)
+        }.to change { Place.count }.by(0)
       end
     end
 


### PR DESCRIPTION
_Fixes_ https://github.com/Terrastories/terrastories/issues/539

This PR adds a spec to ensure places cannot be duplicated through the `Place` importer, if I understood correctly the issue the csv importer was already ensuring a single Place with same attributes is created by using `place = Place.find_or_create_by(decorator.to_h)` in line https://github.com/Terrastories/terrastories/blob/master/rails/app/models/place.rb#L17

