### PR TITLE
557: Update Theme DB seeds from logos to sponsor_logos

### DIFF
--- a/rails/db/seeds.rb
+++ b/rails/db/seeds.rb
@@ -73,5 +73,5 @@ end
 # Create a default theme
 Theme.find_or_create_by!(background_img: 'welcome-bg.jpg') do |theme|
   theme.active = true
-  theme.logos.attach(io: File.open('app/assets/images/rubyforgood.png'), filename: 'rubyforgood.png')
+  theme.sponsor_logos.attach(io: File.open('app/assets/images/rubyforgood.png'), filename: 'rubyforgood.png')
 end


### PR DESCRIPTION
This resolves an error introduced in https://github.com/Terrastories/terrastories/pull/558 , which itself resolved https://github.com/Terrastories/terrastories/issues/557 .

During initial setup `docker-compose exec web bin/setup` fails with message `NoMethodError: undefined method 'logos' for #<Theme:0x0000############>` , traced back to `terrastories/rails/db/seeds.rb`. 

Updating line 76 `theme.logos.attach` to `theme.sponsor_logos.attach` resolves the error and setup succeeds.