### PR TITLE
Attachable Theme background_img

### DIFF
--- a/rails/app/dashboards/theme_dashboard.rb
+++ b/rails/app/dashboards/theme_dashboard.rb
@@ -9,7 +9,7 @@ class ThemeDashboard < Administrate::BaseDashboard
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
     id: Field::Number,
-    background_img: Field::String,
+    background_img: Field::ActiveStorage.with_options({destroy_path: :admin_themes_path}),
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
     sponsor_logos: Field::ActiveStorage.with_options({destroy_path: :admin_themes_path}),

--- a/rails/app/models/theme.rb
+++ b/rails/app/models/theme.rb
@@ -1,6 +1,8 @@
 class Theme < ApplicationRecord
+  has_one_attached :background_img
   has_many_attached :sponsor_logos
 
+  validates :background_img, blob: { content_type: ['image/png', 'image/jpg', 'image/jpeg'] }
   validates :sponsor_logos, blob: { content_type: ['image/png', 'image/jpg', 'image/jpeg'], size_range: 1..5.megabytes }
 end
 

--- a/rails/app/models/theme.rb
+++ b/rails/app/models/theme.rb
@@ -8,9 +8,8 @@ end
 #
 # Table name: themes
 #
-#  id             :bigint           not null, primary key
-#  active         :boolean          default(FALSE), not null
-#  background_img :string
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
+#  id         :bigint           not null, primary key
+#  active     :boolean          default(FALSE), not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
 #

--- a/rails/app/views/welcome/index.html.erb
+++ b/rails/app/views/welcome/index.html.erb
@@ -1,4 +1,4 @@
-<div class="welcome" style="background-image: url(<%= @theme.background_img.present? ? asset_path(@theme.background_img) : asset_path('welcome-bg.jpg') %>) " >
+<div class="welcome" style="background-image: url(<%= @theme.background_img.attached? ? url_for(@theme.background_img) : asset_path('welcome-bg.jpg') %>)" >
   <div class="welcome-card">
     <%= image_tag 'logocombo.svg', alt: 'Terrastories' %>
     <% if user_signed_in? %>

--- a/rails/db/migrate/20201216223155_remove_background_img_from_theme.rb
+++ b/rails/db/migrate/20201216223155_remove_background_img_from_theme.rb
@@ -1,0 +1,5 @@
+class RemoveBackgroundImgFromTheme < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :themes, :background_img, :string
+  end
+end

--- a/rails/db/schema.rb
+++ b/rails/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_13_191300) do
+ActiveRecord::Schema.define(version: 2020_12_16_223155) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -121,7 +121,6 @@ ActiveRecord::Schema.define(version: 2020_12_13_191300) do
   end
 
   create_table "themes", force: :cascade do |t|
-    t.string "background_img"
     t.boolean "active", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/rails/db/seeds.rb
+++ b/rails/db/seeds.rb
@@ -7,17 +7,15 @@
 #   Character.create(name: 'Luke', movie: movies.first)
 
 
-# Create a default theme
-default_theme = Theme.find_or_create_by!(background_img: 'welcome-bg.jpg') do |theme|
-  theme.active = true
-  theme.sponsor_logos.attach(io: File.open('app/assets/images/rubyforgood.png'), filename: 'rubyforgood.png')
-end
-
 # Create a default Community
 default_community = Community.find_or_create_by!(name: "Terrastories") do |community|
   community.country = "United States of America"
   community.locale = "en"
-  community.theme = default_theme
+  community.theme = Theme.create! do |theme|
+    theme.active = true
+    theme.sponsor_logos.attach(io: File.open('app/assets/images/rubyforgood.png'), filename: 'rubyforgood.png')
+    theme.background_img.attach(io: File.open('app/assets/images/welcome-bg.jpg'), filename: 'welcome-bg.jpg')
+  end
 end
 
 # Create Places
@@ -117,7 +115,6 @@ end
 another_community = Community.find_or_create_by!(name: "Ruby for Good") do |community|
   community.country = "United States of America"
   community.locale = "en"
-  community.theme = default_theme
 end
 
 # And community admin user

--- a/rails/spec/factories/theme_factory.rb
+++ b/rails/spec/factories/theme_factory.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :theme do
-    background_img { "welcome-bg.jpg" }
   end
 end


### PR DESCRIPTION
Instead of a db-level string for denoting a URL for where an image is, this allows an image to be uploaded and stored in active storage.

This also updates the seeds to create the Theme when the Community is created. An empty theme is created for a community, if one doesn't exist yet.