### PR TITLE
Feat: Show basic stats on Community page

### DIFF
--- a/rails/app/assets/stylesheets/admin/_card.scss
+++ b/rails/app/assets/stylesheets/admin/_card.scss
@@ -16,6 +16,19 @@
   flex-direction: column;
   justify-content: space-between;
 }
+.cards__item--center {
+  text-align: center;
+}
+
+.cards__item--giant-text {
+  font-size: 4rem;
+  margin-bottom: 1rem;
+}
+
+.cards__item--button {
+  margin: 2rem auto;
+  background-color: $blue;
+}
 
 .cards__item--title {
   font-size: 1.2rem;

--- a/rails/app/models/community.rb
+++ b/rails/app/models/community.rb
@@ -2,6 +2,7 @@ class Community < ApplicationRecord
   has_many :users
   has_many :places
   has_many :stories
+  has_many :speakers
 
   belongs_to :theme, autosave: true
 

--- a/rails/app/policies/story_policy.rb
+++ b/rails/app/policies/story_policy.rb
@@ -37,13 +37,14 @@ class StoryPolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      stories = user.community.stories.where(permission_level: :anonymous)
-      if user&.member?
-          stories = user.community.stories.where(permission_level: [:anonymous, :user_only])
+      if user&.super_admin || user&.editor? || user&.admin?
+        stories = scope.all
+      elsif user&.member?
+        stories = scope.where(permission_level: [:anonymous, :user_only])
+      else
+        stories = scope.where(permission_level: :anonymous)
       end
-      if user&.editor? || user&.admin?
-          stories = user.community.stories.all
-      end
+
       stories.eager_load(:speakers, :places)
     end
 

--- a/rails/app/policies/story_policy.rb
+++ b/rails/app/policies/story_policy.rb
@@ -37,12 +37,15 @@ class StoryPolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      if user&.super_admin || user&.editor? || user&.admin?
+      if user&.super_admin
+        # this is so the admin page doesn't throw a nil error for super admins looking at community dashboard
         stories = scope.all
+      elsif user&.editor? || user&.admin?
+        stories = scope.where(community: user.community).all
       elsif user&.member?
-        stories = scope.where(permission_level: [:anonymous, :user_only])
+        stories = scope.where(community: user.community, permission_level: [:anonymous, :user_only])
       else
-        stories = scope.where(permission_level: :anonymous)
+        stories = scope.where(community: user.community, permission_level: :anonymous)
       end
 
       stories.eager_load(:speakers, :places)

--- a/rails/app/views/admin/communities/show.html.erb
+++ b/rails/app/views/admin/communities/show.html.erb
@@ -19,6 +19,32 @@
   <span class="badge"><%= page.resource.country %></span>
 </section>
 
+<% if current_user.member? || current_user.editor? || current_user.admin? || current_user.super_admin %>
+  <section class="main-content__body main-content__body--split padding-fix color-fix cards">
+    <div class="cards__item cards__item--center">
+      <span class="cards__item--giant-text"><%= policy_scope(page.resource.stories).count %></span>
+      <h3><%= t("stories") %></h3>
+      <%= link_to(
+        t("administrate.actions.new_resource", name: t("administrate.story")), new_admin_story_path, class: "button cards__item--button"
+        ) if valid_action?(:new) && show_action?(:new, Story.new) %>
+    </div>
+    <div class="cards__item cards__item--center">
+      <span class="cards__item--giant-text"><%= policy_scope(page.resource.places).count %></span>
+      <h3><%= t("places") %></h3>
+      <%= link_to(
+        t("administrate.actions.new_resource", name: t("administrate.place")), new_admin_place_path, class: "button cards__item--button"
+        ) if valid_action?(:new) && show_action?(:new, Place.new) %>
+    </div>
+    <div class="cards__item cards__item--center">
+      <span class="cards__item--giant-text"><%= policy_scope(page.resource.speakers).count %></span>
+      <h3><%= t("speakers") %></h3>
+      <%= link_to(
+        t("administrate.actions.new_resource", name: t("administrate.speaker")), new_admin_speaker_path, class: "button cards__item--button"
+        ) if valid_action?(:new) && show_action?(:new, Speaker.new) %>
+    </div>
+  </section>
+<% end %>
+
 <% if current_user.super_admin %>
   <section class="main-content__body main-content__body--flush padding-fix color-fix">
     <header class="main-content__header" role="heading">


### PR DESCRIPTION
This adds a basic stats page for the community, listing the number of stories, speakers, and places the instance has. 

1. Viewers cannot see the stats
2. Members can only see (story) stats for the ones they are allowed to see 
3. Editors + Admins can see all stats.

There may be some additional scoping we need to do for places/speakers.

This also adds "quick links" on those number cards for editors+.

Super Admins can see all of the stats, but do not have quick links for creating any records. Eventually, we'll want to build a super dashboard for system-wide stats/analytics rather than just per community.

## Screenshots of Community Page

<details>
<summary>Viewer</summary>

<img width="1379" alt="Screen Shot 2020-12-17 at 9 21 59 AM" src="https://user-images.githubusercontent.com/2660801/102515414-beaad380-405b-11eb-83a9-4b1afc314c7d.png">
</details>

<details>
<summary>Member</summary>

<img width="1378" alt="Screen Shot 2020-12-17 at 9 20 37 AM" src="https://user-images.githubusercontent.com/2660801/102515531-e00bbf80-405b-11eb-9308-ef06698390f2.png">
</details>

<details>
<summary>Editor</summary>

<img width="1378" alt="Screen Shot 2020-12-17 at 9 22 25 AM" src="https://user-images.githubusercontent.com/2660801/102515550-e601a080-405b-11eb-8db5-b562bc8ec9de.png">
</details>

<details>
<summary>Admin</summary>

<img width="1379" alt="Screen Shot 2020-12-17 at 9 23 07 AM" src="https://user-images.githubusercontent.com/2660801/102515577-eb5eeb00-405b-11eb-8e83-74742d2a9cd7.png">
</details>

<details>
<summary>Super Admin</summary>

<img width="1378" alt="Screen Shot 2020-12-17 at 9 23 29 AM" src="https://user-images.githubusercontent.com/2660801/102515594-f0bc3580-405b-11eb-9f58-880576eb73d8.png">
<img width="1378" alt="Screen Shot 2020-12-17 at 9 23 42 AM" src="https://user-images.githubusercontent.com/2660801/102515601-f1ed6280-405b-11eb-8567-25d740222617.png">
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/2660801/102515743-1d704d00-405c-11eb-865c-524c422cc380.png">

</details>