### PR TITLE
Fix: permissions issue

### DIFF
--- a/rails/app/dashboards/user_dashboard.rb
+++ b/rails/app/dashboards/user_dashboard.rb
@@ -10,7 +10,7 @@ class UserDashboard < Administrate::BaseDashboard
   ATTRIBUTE_TYPES = {
     id: Field::Number,
     email: Field::String,
-    role: EnumField,
+    role: EnumField.with_options(skip: :super_admin),
     password: Field::Password,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,

--- a/rails/app/fields/enum_field.rb
+++ b/rails/app/fields/enum_field.rb
@@ -6,7 +6,7 @@ class EnumField < Administrate::Field::Base
   end
 
   def select_field_values(form_builder)
-    form_builder.object.class.public_send(attribute.to_s.pluralize).keys.map do |v|
+    form_builder.object.class.public_send(attribute.to_s.pluralize).keys.reject { |k| k.to_sym == options[:skip] }.map do |v|
       [v.titleize, v]
     end
   end

--- a/rails/app/views/admin/users/_form.html.erb
+++ b/rails/app/views/admin/users/_form.html.erb
@@ -34,7 +34,7 @@ and renders all form fields for a resource's editable attributes.
   <% end %>
 
   <% page.attributes.each do |attribute| -%>
-    <% next if attribute.attribute == :role && !(current_user.super_admin || current_user.admin?) -%>
+    <% next if attribute.attribute == :role && !((current_user.super_admin || current_user.admin?) && page.resource.id != current_user.id) -%>
     <div class="field-unit field-unit--<%= attribute.html_class %> field-unit--<%= requireness(attribute) %>">
       <%= render_field attribute, f: f %>
     </div>


### PR DESCRIPTION
Editors/Admins could edit their own role; which caused them to lose the
privileges (or gain privileges) they weren't allowed to have.

Furthermore, super admin is for internal use only, and so that role
should be removed from the list of role options; this is done by adding
options :skip to skip keys in the enum