### PR TITLE
Customize Mapbox Map Style and Access Token in Theme

### DIFF
--- a/rails/app/controllers/home_controller.rb
+++ b/rails/app/controllers/home_controller.rb
@@ -23,4 +23,20 @@ class HomeController < ApplicationController
   helper_method def stories
     policy_scope(Story)
   end
+
+  helper_method def mapbox_token
+    current_community.theme.mapbox_access_token || ENV["MAPBOX_ACCESS_TOKEN"]
+  end
+
+  helper_method def local_mapbox?
+    ENV["USE_LOCAL_MAP_SERVER"].present?
+  end
+
+  helper_method def mapbox_style
+    if local_mapbox?
+      "http://localhost:8080/styles/basic/style.json"
+    else
+      current_community.theme.mapbox_style_url || ENV["MAPBOX_STYLE"]
+    end
+  end
 end

--- a/rails/app/dashboards/theme_dashboard.rb
+++ b/rails/app/dashboards/theme_dashboard.rb
@@ -13,6 +13,8 @@ class ThemeDashboard < Administrate::BaseDashboard
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
     sponsor_logos: Field::ActiveStorage.with_options({destroy_path: :admin_themes_path}),
+    mapbox_style_url: Field::String,
+    mapbox_access_token: Field::String,
   }.freeze
 
   # COLLECTION_ATTRIBUTES
@@ -29,11 +31,10 @@ class ThemeDashboard < Administrate::BaseDashboard
   # SHOW_PAGE_ATTRIBUTES
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = %i[
-  id
   background_img
-  created_at
-  updated_at
   sponsor_logos
+  mapbox_style_url
+  mapbox_access_token
   ].freeze
 
   # FORM_ATTRIBUTES
@@ -42,6 +43,8 @@ class ThemeDashboard < Administrate::BaseDashboard
   FORM_ATTRIBUTES = %i[
   background_img
   sponsor_logos
+  mapbox_style_url
+  mapbox_access_token
   ].freeze
 
   # COLLECTION_FILTERS

--- a/rails/app/models/theme.rb
+++ b/rails/app/models/theme.rb
@@ -10,8 +10,10 @@ end
 #
 # Table name: themes
 #
-#  id         :bigint           not null, primary key
-#  active     :boolean          default(FALSE), not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id                  :bigint           not null, primary key
+#  active              :boolean          default(FALSE), not null
+#  mapbox_access_token :string
+#  mapbox_style_url    :string
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
 #

--- a/rails/app/views/home/_home.json.jbuilder
+++ b/rails/app/views/home/_home.json.jbuilder
@@ -23,7 +23,7 @@ json.stories stories do |story|
 end
 json.logo_path image_path("logocombo.svg")
 json.user current_user
-json.mapbox_access_token ENV["MAPBOX_ACCESS_TOKEN"]
-json.mapbox_style ENV["USE_LOCAL_MAP_SERVER"].present? ? "http://localhost:8080/styles/basic/style.json" : ENV["MAPBOX_STYLE"]
-json.use_local_map_server ENV["USE_LOCAL_MAP_SERVER"].present?
+json.mapbox_access_token mapbox_token
+json.mapbox_style mapbox_style
+json.use_local_map_server local_mapbox?
 json.marker_image_url image_url("marker1.png")

--- a/rails/db/migrate/20201218143646_add_mapbox_attributes_to_theme.rb
+++ b/rails/db/migrate/20201218143646_add_mapbox_attributes_to_theme.rb
@@ -1,0 +1,6 @@
+class AddMapboxAttributesToTheme < ActiveRecord::Migration[5.2]
+  def change
+    add_column :themes, :mapbox_style_url, :string
+    add_column :themes, :mapbox_access_token, :string
+  end
+end

--- a/rails/db/schema.rb
+++ b/rails/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_16_223155) do
+ActiveRecord::Schema.define(version: 2020_12_18_143646) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -124,6 +124,8 @@ ActiveRecord::Schema.define(version: 2020_12_16_223155) do
     t.boolean "active", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "mapbox_style_url"
+    t.string "mapbox_access_token"
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
This adds the ability for admins to update the Theme to a custom mapbox map and access token, allowing a community to customize the style of their specific map view.

## Changes

* Adds db migration to add mapbox_style_url and mapbox_access_token to Theme table
* Updates theme administrate dashboard to allow editing for mapbox attributes ☝️ 
* Uses helper methods to switch between offline (local) mode, theme mapbox styles, and environmental variables fallback.

## Notes

# Fallback
<img width="1502" alt="image" src="https://user-images.githubusercontent.com/2660801/102628297-75b85500-4117-11eb-8d46-145f06e04434.png">

# Theme set
<img width="1500" alt="image" src="https://user-images.githubusercontent.com/2660801/102628369-8ff23300-4117-11eb-86c1-a4f2f0c8b341.png">
