### PR TITLE
Ensure flash messages are shown on Devise sessions/sign in page

### DIFF
--- a/rails/app/assets/stylesheets/components/devise.scss
+++ b/rails/app/assets/stylesheets/components/devise.scss
@@ -8,6 +8,18 @@
   align-items: center;
   text-align: center;
 
+  .flashes {
+    margin-bottom: 1rem;
+
+    .flash-alert {
+      color: $dark-red;
+    }
+
+    .flash-notice {
+      color: $dark-orange;
+    }
+  }
+
   .logo {
     img {
       width: 50%;

--- a/rails/app/views/devise/sessions/new.html.erb
+++ b/rails/app/views/devise/sessions/new.html.erb
@@ -4,6 +4,16 @@
     <h1><%= t("welcome") %></h1>
 
     <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+      <% if flash.any? %>
+        <div class="flashes">
+          <% flash.each do |key, value| -%>
+            <div class="flash flash-<%= key %>">
+              <%= value.html_safe %>
+            </div>
+          <% end -%>
+        </div>
+      <% end %>
+
       <div class="field">
         <%= f.label :email %>
         <%= f.email_field :email, autofocus: true, autocomplete: "email" %>


### PR DESCRIPTION
Fixes #584

## Issue

The sessions new page utilizes flash messaging to display errors. Since the layout for devise does not include flash messaging, these messages were never shown to the user.

## Fix

At first, I added them to the layout; but noticed that the flash messages ended up being way far away from the focal point of the form and what went wrong. Instead, I added them directly to the sign in form area to keep the messaging near where their eyes already are.

<img width="410" alt="image" src="https://user-images.githubusercontent.com/2660801/103293874-bab57480-49be-11eb-99f6-e835ad600053.png">
