### PR TITLE
Use .presence check for mapbox access and style attributes

### DIFF
--- a/rails/app/controllers/home_controller.rb
+++ b/rails/app/controllers/home_controller.rb
@@ -25,7 +25,7 @@ class HomeController < ApplicationController
   end
 
   helper_method def mapbox_token
-    current_community.theme.mapbox_access_token || ENV["MAPBOX_ACCESS_TOKEN"]
+    current_community.theme.mapbox_access_token.presence || ENV["MAPBOX_ACCESS_TOKEN"]
   end
 
   helper_method def local_mapbox?
@@ -36,7 +36,7 @@ class HomeController < ApplicationController
     if local_mapbox?
       "http://localhost:8080/styles/basic/style.json"
     else
-      current_community.theme.mapbox_style_url || ENV["MAPBOX_STYLE"]
+      current_community.theme.mapbox_style_url.presence || ENV["MAPBOX_STYLE"]
     end
   end
 end


### PR DESCRIPTION
Fixes #603 

On first creation, Theme attribute for mapbox style and mapbox token are set to nil; which is why the old code worked. Once the Theme was saved, Administrate was setting those fields to empty strings, which no longer works with the standard `||` check:

```ruby
nil || "hey"
#=> "hey"

"" || "hey"
#=> ""
```

By using `.presence` which checks for blank string values instead of just nil/false, the mapbox style and token correctly fall back to the environment defaults.