### PR TITLE
Fix X button in map Marker containing an image (#600)

### DIFF
--- a/rails/app/assets/stylesheets/components/_balloon.scss
+++ b/rails/app/assets/stylesheets/components/_balloon.scss
@@ -11,6 +11,7 @@
 
   &-header {
     display: flex;
+    justify-content: space-between;
     background-color: $green; /* this should inherit the color of the marker associated with the type of place */
     &-button {
       align-self: flex-start;


### PR DESCRIPTION
Hi! This is a fix for #600. I tested it for markers with and without images, both long and short names (issue exists for short names only). 