### PR TITLE
Create `production` AWS storage src in Rails

### DIFF
--- a/rails/config/storage.yml
+++ b/rails/config/storage.yml
@@ -14,6 +14,15 @@ amazon:
   region: <%= ENV.fetch("AWS_REGION", "us-east-2") %>
   bucket: <%= ENV.fetch("AWS_BUCKET_NAME", "terrastories-demo") %>
 
+# This is for the primary online multi-instance.
+# It does not use the shared AWS environment that is used by `amazon` in our staging/demo environments.
+production:
+  service: S3
+  access_key_id: <%= ENV.fetch("AWS_ACCESS_KEY") %>
+  secret_access_key: <%= ENV.fetch("AWS_SECRET_ACCESS_KEY") %>
+  region: <%= ENV.fetch("AWS_REGION", "us-east-2") %>
+  bucket: <%= ENV.fetch("AWS_BUCKET_NAME", "terrastories-demo") %>
+
 # Remember not to checkin your GCS keyfile to a repository
 # google:
 #   service: GCS


### PR DESCRIPTION
Before any environment could utilize the "amazon" storage contained in the storage.yml file. This is fine for local dev with actual Amazon S3 or for our staging and demo environments. For production now, with multi-instance single host, a dedicated private bucket seems prudent.

This will have no affect on current instance setups and will only affect new instances that set ACTIVE_STORAGE_SRC to production.