### PR TITLE
Move RFG logo to main login screen

### DIFF
--- a/rails/app/assets/stylesheets/components/devise.scss
+++ b/rails/app/assets/stylesheets/components/devise.scss
@@ -22,7 +22,9 @@
 
   .logo {
     img {
-      width: 50%;
+      max-width: 120px;
+      width: 14vh;
+      height: auto;
     }
   }
 
@@ -39,6 +41,7 @@
     flex-shrink: 0;
     @media screen and (max-width: 600px) {
       width: 80vw;
+      margin-bottom: 10px;
     }
 
     img {
@@ -94,11 +97,6 @@
       }
     }
   }
-  @include for-phone-only {
-    .logo {
-      height: 25%;
-    }
-  }
   @media screen and (max-width: 370px) {
     h1 {
       font-size: 1.5rem;
@@ -114,7 +112,11 @@
       font-size: 0.6em;
     }
   }
-  @media screen and (max-height: 450px) {
+  @media screen and (max-height: 550px) {
+    .built-with {
+      display: none;
+    }
+
     .logo {
       display: none;
     }

--- a/rails/app/assets/stylesheets/components/welcome.scss
+++ b/rails/app/assets/stylesheets/components/welcome.scss
@@ -11,8 +11,8 @@
   .logo {
     img {
       max-width: 200px;
-      width: 15vw;
-      height:auto;
+      width: 15vh;
+      height: auto;
     }
   }
 
@@ -26,7 +26,7 @@
     height: 20rem;
     display: flex;
     flex-direction: column;
-    margin-bottom: 40px;
+    margin-bottom: 20px;
     flex-shrink: 0;
     @media screen and (max-width: 600px) {
       width: 80vw;

--- a/rails/app/views/devise/sessions/new.html.erb
+++ b/rails/app/views/devise/sessions/new.html.erb
@@ -44,4 +44,9 @@
     <%= render "devise/shared/links" %>
 
   </div>
+  <span class="built-with">Built with ❤️ by</span>
+  <div class="logo">
+    <%= image_tag "rubyforgood.png" %>
+  </div>
+
 </div>

--- a/rails/app/views/welcome/index.html.erb
+++ b/rails/app/views/welcome/index.html.erb
@@ -30,14 +30,12 @@
     </div>
   </div>
   <% if @theme %>
-  Built with ❤️ by
-  <div class="logo">
-    <%= image_tag "rubyforgood.png" %>
-    <% if @theme %>
-      <% @theme.sponsor_logos.each do |logo| %>
-        <%= image_tag logo %>
+    <div class="logo">
+      <% if @theme %>
+        <% @theme.sponsor_logos.each do |logo| %>
+          <%= image_tag logo %>
+        <% end %>
       <% end %>
-    <% end %>
+    </div>
   <% end %>
-  </div>
 </div>


### PR DESCRIPTION
Fixes #582


Login:

![login-desktop](https://user-images.githubusercontent.com/1314522/108634479-06921080-747a-11eb-88b9-3b74aa4d60ec.png)
![login-mobile](https://user-images.githubusercontent.com/1314522/108634484-0a259780-747a-11eb-8e20-042f508b414e.png)

Welcome (RFG used as sponsor logo):

![welcome-desktop](https://user-images.githubusercontent.com/1314522/108634468-fc701200-7479-11eb-9f6e-7edc07da0034.png)
![welcome-mobile](https://user-images.githubusercontent.com/1314522/108634503-10b40f00-747a-11eb-9fcf-6b2f46f424c1.png)