### PR TITLE
Don't set theme on search index (no community set)

### DIFF
--- a/rails/app/controllers/home_controller.rb
+++ b/rails/app/controllers/home_controller.rb
@@ -1,6 +1,6 @@
 # The home controller
 class HomeController < ApplicationController
-  before_action :set_theme
+  before_action :set_theme, except: :community_search_index
 
   def index
     if current_user.super_admin


### PR DESCRIPTION
#615 added configurable themes - which is awesome! 

Unfortunately, if the user is not part of a community and gets directed into the WIP community search index, the controller still attempts to set the theme which causes a 500 error.

This patches the before action to skip that search index.