### PR TITLE
Fix key error when setting up app

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,3 @@
-  
 # This is only for setting up your development environment. Please reach out to the stewards of Terrastories for how to setup your environment for production.
 NGINX_PORT=3000
 MAPBOX_STYLE=mapbox://styles/mapbox/light-v10
@@ -10,3 +9,7 @@ DB_HOST=db
 ACTIVE_STORAGE_SRC="local"
 AWS_REGION="us-east-2"
 AWS_BUCKET_NAME="terrastories-demo"
+# Any value assigned to these 2 last ones should work
+# (Keys added as a workaround since `docker-compose exec web bin/setup` wouldnt work without them)
+AWS_ACCESS_KEY="terrastories"
+AWS_SECRET_ACCESS_KEY="terrastories"


### PR DESCRIPTION
Keys added as a workaround since `docker-compose exec web bin/setup` wouldnt work without them