### PR TITLE
606 replace email with username

### DIFF
--- a/rails/app/controllers/application_controller.rb
+++ b/rails/app/controllers/application_controller.rb
@@ -13,6 +13,10 @@ class ApplicationController < ActionController::Base
   end
 
   private
+  
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:username)
+  end
 
   def set_locale
     I18n.locale = params[:locale] || I18n.default_locale

--- a/rails/app/controllers/registrations_controller.rb
+++ b/rails/app/controllers/registrations_controller.rb
@@ -3,10 +3,10 @@ class RegistrationsController < Devise::RegistrationsController
     private
   
     def sign_up_params
-      params.require(:user).permit(:email, :role, :password, :password_confirmation)
+      params.require(:user).permit(:email, :username, :role, :password, :password_confirmation)
     end
   
     def account_update_params
-      params.require(:user).permit(:email, :role, :password, :password_confirmation, :current_password)
+      params.require(:user).permit(:email, :username, :role, :password, :password_confirmation, :current_password)
     end
   end

--- a/rails/app/dashboards/user_dashboard.rb
+++ b/rails/app/dashboards/user_dashboard.rb
@@ -9,7 +9,7 @@ class UserDashboard < Administrate::BaseDashboard
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
     id: Field::Number,
-    email: Field::String,
+    username: Field::String,
     role: EnumField.with_options(skip: :super_admin),
     password: Field::Password,
     created_at: Field::DateTime,
@@ -43,7 +43,7 @@ class UserDashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = [
-    :email,
+    :username,
     :password,
     :role,
     :photo
@@ -53,7 +53,7 @@ class UserDashboard < Administrate::BaseDashboard
   # across all pages of the admin dashboard.
   #
   def display_resource(user)
-    user.email
+    user.username
   end
 
   def permitted_attributes

--- a/rails/app/models/user.rb
+++ b/rails/app/models/user.rb
@@ -29,6 +29,7 @@ end
 #  id                     :bigint           not null, primary key
 #  current_sign_in_at     :datetime
 #  current_sign_in_ip     :string
+#  username               :string           default(""), not null
 #  email                  :string           default(""), not null
 #  encrypted_password     :string           default(""), not null
 #  last_sign_in_at        :datetime

--- a/rails/app/views/devise/registrations/new.html.erb
+++ b/rails/app/views/devise/registrations/new.html.erb
@@ -11,6 +11,11 @@
       </div>
 
       <div class="field">
+        <%= f.label :username %>
+        <%= f.text_field :username, autofocus: true, autocomplete: "username" %>
+      </div>
+
+      <div class="field">
         <%= f.label :password %>
         <% if @minimum_password_length %>
         <em>(<%= @minimum_password_length %> characters minimum)</em>

--- a/rails/app/views/devise/sessions/new.html.erb
+++ b/rails/app/views/devise/sessions/new.html.erb
@@ -15,8 +15,8 @@
       <% end %>
 
       <div class="field">
-        <%= f.label :email %>
-        <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+        <%= f.label :username, t("username") %>
+        <%= f.text_field :username, autofocus: true, autocomplete: "off" %>
       </div>
 
       <div class="field">

--- a/rails/config/initializers/devise.rb
+++ b/rails/config/initializers/devise.rb
@@ -40,7 +40,7 @@ Devise.setup do |config|
   # session. If you need permissions, you should implement that in a before filter.
   # You can also supply a hash where the value is a boolean determining whether
   # or not authentication should be aborted when the value is not present.
-  # config.authentication_keys = [:email]
+  config.authentication_keys = [:username]
 
   # Configure parameters from the request object used for authentication. Each entry
   # given should be a request method and it will automatically be passed to the
@@ -52,12 +52,12 @@ Devise.setup do |config|
   # Configure which authentication keys should be case-insensitive.
   # These keys will be downcased upon creating or modifying a user and when used
   # to authenticate or find a user. Default is :email.
-  config.case_insensitive_keys = [:email]
+  config.case_insensitive_keys = [:username]
 
   # Configure which authentication keys should have whitespace stripped.
   # These keys will have whitespace before and after removed upon creating or
   # modifying a user and when used to authenticate or find a user. Default is :email.
-  config.strip_whitespace_keys = [:email]
+  config.strip_whitespace_keys = [:username]
 
   # Tell if authentication through request.params is enabled. True by default.
   # It can be set to an array that will enable params authentication only for the

--- a/rails/db/migrate/20210425165922_add_username_to_users.rb
+++ b/rails/db/migrate/20210425165922_add_username_to_users.rb
@@ -1,0 +1,6 @@
+class AddUsernameToUsers < ActiveRecord::Migration[5.2]
+  def change
+  	add_column :users, :username, :string, null: false, default: ''
+  	add_index :users, :username, unique: true
+  end
+end

--- a/rails/db/schema.rb
+++ b/rails/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_23_183008) do
+ActiveRecord::Schema.define(version: 2021_04_25_165922) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -138,6 +138,7 @@ ActiveRecord::Schema.define(version: 2021_03_23_183008) do
   end
 
   create_table "users", force: :cascade do |t|
+    t.string "username", default: "", null: false
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
@@ -154,6 +155,7 @@ ActiveRecord::Schema.define(version: 2021_03_23_183008) do
     t.integer "community_id"
     t.boolean "super_admin", default: false, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["username"], name: "index_users_on_username", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 

--- a/rails/db/seeds.rb
+++ b/rails/db/seeds.rb
@@ -81,6 +81,7 @@ shared_story = Story.find_or_create_by(title: "Terrastories Team testimonial",
 
 # Create a default admin user
 User.find_or_create_by!(email: 'admin@terrastories.com') do |admin|
+  admin.username = 'admin'
   admin.password = 'terrastories'
   admin.password_confirmation = 'terrastories'
   admin.role = 2
@@ -89,6 +90,7 @@ end
 
 # Create a example editor user
 User.find_or_create_by!(email: 'editor@terrastories.com') do |admin|
+  admin.username = 'editor'
   admin.password = 'terrastories'
   admin.password_confirmation = 'terrastories'
   admin.role = 1
@@ -97,6 +99,7 @@ end
 
 # Create a example member user
 User.find_or_create_by!(email: 'user@terrastories.com') do |admin|
+  admin.username = 'user'
   admin.password = 'terrastories'
   admin.password_confirmation = 'terrastories'
   admin.role = 0
@@ -105,6 +108,7 @@ end
 
 # Create a example viewer user
 User.find_or_create_by!(email: 'viewer@terrastories.com') do |user|
+  user.username = 'viewer'
   user.password = 'terrastories'
   user.password_confirmation = 'terrastories'
   user.role = 3
@@ -119,6 +123,7 @@ end
 
 # And community admin user
 User.find_or_create_by!(email: 'admin@r4g.com') do |admin|
+  admin.username = 'adminr4g'
   admin.password = 'terrastories'
   admin.password_confirmation = 'terrastories'
   admin.role = 2
@@ -127,6 +132,7 @@ end
 
 # Super Admin user for Terrastories
 User.find_or_create_by!(email: "super@terrastories.com") do |admin|
+  admin.username = 'super'
   admin.password = 'terrastories'
   admin.password_confirmation = 'terrastories'
   admin.role = 100
@@ -135,6 +141,7 @@ end
 
 # Public user, not associated with Community
 User.find_or_create_by!(email: "public@terrastories.com") do |admin|
+  admin.username = 'public'
   admin.password = 'terrastories'
   admin.password_confirmation = 'terrastories'
   admin.role = 100

--- a/rails/spec/factories/user_factory.rb
+++ b/rails/spec/factories/user_factory.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :user do
     email { 'trashme@example.com' }
+    username { 'username' }
     password { 'password' }
     community
   end

--- a/rails/spec/models/model_spec.rb
+++ b/rails/spec/models/model_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Model, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
Added username field to users table. Users log in with a username instead of email. When creating an account there is also a username field. Previous references to email in user dashboards replaced with username. Work still needs to be done to make email not required when creating an account, but that will take some consideration into how to manage an account without an email associated with it. 