### PR TITLE
Add ability to delete speaker photo

### DIFF
--- a/rails/app/controllers/admin/speakers_controller.rb
+++ b/rails/app/controllers/admin/speakers_controller.rb
@@ -71,5 +71,11 @@ module Admin
     def export_sample_csv
       send_data Speaker.export_sample_csv, filename: "sample_speakers.csv"
     end
+
+    def delete_photo
+      photo = requested_resource.photos.find(params[:attachment_id])
+      photo.purge
+      redirect_back(fallback_location: requested_resource)
+    end
   end
 end

--- a/rails/app/dashboards/speaker_dashboard.rb
+++ b/rails/app/dashboards/speaker_dashboard.rb
@@ -9,7 +9,7 @@ class SpeakerDashboard < Administrate::BaseDashboard
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
     id: Field::Number,
-    photo: Field::ActiveStorage,
+    photo: Field::ActiveStorage.with_options({destroy_path: :photos_admin_speaker_path}),
     name: Field::String,
     stories: Field::ScopedHasMany.with_options(scope: -> (field) { field.resource.community.stories }),
     birthdate: Field::DateTime.with_options(format: "%d/%m/%Y"),

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
         get  :import_page
         get  :export_sample_csv
       end
+      delete :photos, on: :member, action: :delete_photo
     end
     resources :stories do
       collection do


### PR DESCRIPTION
Issue [#588](https://github.com/Terrastories/terrastories/issues/521)

This PR includes:

- Modify Speaker controller
- Modify Speaker dashboard
- Modify routes

WIP:
Getting the error `No route matches {:action=>"delete_photo", :attachment_id=>3, :controller=>"admin/speakers", :record_id=>4}, missing required keys: [:id]`

I'm passing `photos_admin_speaker_path` to speaker dashboard, which is route
`DELETE | /admin/speakers/:id/photos(.:format) | admin/speakers#delete_photo`

I'm using `destroy_path` at Speaker dashboard because I saw that's what is being used in Story, Theme and Place.



