### PR TITLE
Fix sprites and add Mapeo documentation

### DIFF
--- a/documentation/CUSTOMIZATION.md
+++ b/documentation/CUSTOMIZATION.md
@@ -22,7 +22,7 @@ To set the map style used by Terrastories, modify the `MAPBOX_STYLE` variable in
 
 You can also set a `Mapbox.com` map for a community in the `Theme` menu when logged in as an admin user. Paste in the map style URL, and your map token, in the fields and it will automatically update the map for that community instance.
 
-For offline "Field Kit" usage of Terrastories, it is necessary to create your own custom map using your own GIS data, as above. There are several additional steps to generate and style the `MBTiles`, described in the [SETUP-OFFLINE.md](SETUP-OFFLINE.md) file. It's also possible to get offline basemaps for [Mapeo](https://mapeo.app) working in Terrastories: please see our Mapeo to Terrastories guide(MAPEO-MAPS-IN-TERRASTORIES.md).
+For offline "Field Kit" usage of Terrastories, it is necessary to create your own custom map using your own GIS data, as above. There are several additional steps to generate and style the `MBTiles`, described in the [SETUP-OFFLINE.md](SETUP-OFFLINE.md) file. It's also possible to get offline basemaps for [Mapeo](https://mapeo.app) working in Terrastories: please see our [Mapeo to Terrastories guide](MAPEO-MAPS-IN-TERRASTORIES.md).
 
 _**Note:** when using Mapbox.com maps with Terrastories, you are subject to Mapbox's [pricing schema](https://www.mapbox.com/pricing/) which has a free tier of up to 50,000 map loads per month. If you anticipate more monthly loads than that, you can get in touch with Mapbox's community team at community@mapbox.com to see what they can do to help._
 

--- a/documentation/CUSTOMIZATION.md
+++ b/documentation/CUSTOMIZATION.md
@@ -22,7 +22,7 @@ To set the map style used by Terrastories, modify the `MAPBOX_STYLE` variable in
 
 You can also set a `Mapbox.com` map for a community in the `Theme` menu when logged in as an admin user. Paste in the map style URL, and your map token, in the fields and it will automatically update the map for that community instance.
 
-For offline "Field Kit" usage of Terrastories, it is necessary to create your own custom map using your own GIS data, as above. There are several additional steps to generate and style the `MBTiles`, described in the [SETUP-OFFLINE.md](SETUP-OFFLINE.md) file.
+For offline "Field Kit" usage of Terrastories, it is necessary to create your own custom map using your own GIS data, as above. There are several additional steps to generate and style the `MBTiles`, described in the [SETUP-OFFLINE.md](SETUP-OFFLINE.md) file. It's also possible to get offline basemaps for [Mapeo](https://mapeo.app) working in Terrastories: please see our Mapeo to Terrastories guide(MAPEO-MAPS-IN-TERRASTORIES.md).
 
 _**Note:** when using Mapbox.com maps with Terrastories, you are subject to Mapbox's [pricing schema](https://www.mapbox.com/pricing/) which has a free tier of up to 50,000 map loads per month. If you anticipate more monthly loads than that, you can get in touch with Mapbox's community team at community@mapbox.com to see what they can do to help._
 

--- a/documentation/MAPEO-MAPS-IN-TERRASTORIES.md
+++ b/documentation/MAPEO-MAPS-IN-TERRASTORIES.md
@@ -1,0 +1,41 @@
+The [Terrastories](https://www.notion.so/Terrastories-d61ccbf6dba345d1aa7f616fe4d54f6f) application uses a tileserver `TileServer-GL` developed by KlokanTech, which reads a different tile format than Mapeo: MBTiles. MBTiles is a tile format that stores tiles in a SQLite database rather than in individual folders like the tiles used by Mapeo. 
+
+There are various pathways to convert tiles generated for Mapeo working in Terrastories.
+
+### Converting raster tiles for Terrastories
+
+1. Using QGIS:
+    1. Load the tiles that you've generated for Mapeo into QGIS by adding the folder as a New Connection in XYZ Tiles in the Browser panel, and then add them to your map canvas.
+    2. Next, use the `Generate XYZ Tiles (MBTiles)` tool to generate MBTiles. The parameters should generally stay the same, but you may want to set the Tile Format to JPG and set a minimum and maximum zoom level.
+2. Using TL:
+    1. In a terminal, navigate to the directory where your tiles are located, and run a conversion command like `tl copy -z 1 -Z 16 file://./**tile-directory** mbtiles://./**tiles**.mbtiles` where **tile-directory** is the name of the directory, and **tiles** is the name you want to give your mbtiles file.
+
+Either pathway will generate a raster `.mbtiles` file which you can add to Terrastories in the `/tileserver/data/mbtiles` directory, and then define in `style.json` (more on that in the Terrastories documentation [here](https://github.com/Terrastories/terrastories/blob/master/documentation/SETUP-OFFLINE.md#setting-up-offline-environment-and-map)).
+
+### Converting vector tiles for Terrastories
+
+1. Converting the tiles to MBTiles
+    1. Using TL:
+        1. In a terminal, navigate to the directory where your tiles are located, and run a conversion command like `tl copy -z 1 -Z 16 file://./**tile-directory** mbtiles://./**tiles**.mbtiles` where **tile-directory** is the name of the directory, and **tiles** is the name you want to give your mbtiles file.
+2. Editing the style.json
+    1. In the `style.json` file that comes with the tiles generated for Mapeo, replace the `sources` → `composite` content with the following: 
+
+    ```jsx
+    "composite": {
+    "url": "mbtiles://mbtiles/tiles.mbtiles",
+    "type": "vector"
+    }
+    ```
+
+    In addition, change the sprites and glyphs definitions to the following:
+
+    ```jsx
+    "sprite": "sprite",
+    "glyphs": "{fontstack}/{range}.pbf",
+    ```
+
+3. Place the MBTiles, style.json, sprites, and font glyphs in the Terrastories tileserver directory, and adapt `config.json`. 
+    1. There are dedicated folders for the `MBTiles`, sprites, and glyphs.
+    2. In `config.json`, set the `"mbtiles":` definition to your MBTiles file. 
+
+With all of this done, the next time you start Terrastories for offline mode it should load the vector tiles successfully as the basemap. (You can also check the tileserver directly by visiting `localhost:8080`.

--- a/documentation/SETUP-OFFLINE.md
+++ b/documentation/SETUP-OFFLINE.md
@@ -36,7 +36,7 @@ Terrastories in the "Field Kit" environment works by integrating map `tiles` and
 
 * The open-source GIS software QGIS has several tools for generating `MBTiles` in both raster and vector format. `Generate XYZ tiles (MBTiles)` can be used to create raster tiles of all of the content on your map canvas; this may also include XYZ Tiles from services such as OpenStreetMap, Bing, and Google Satellite. `Generate Vector Tiles (MBTiles)` can be used to create vector tiles from one or more vector layers. You can then further style these vector tiles in your ` style.json` file.
 * There is also a command line option to generate vector `MBTiles` called `tippecanoe`, created by Mapbox: [guide](https://docs.mapbox.com/help/troubleshooting/large-data-tippecanoe/).
-* If you already have tiles in a different format (like in the `tilelive-file` used by [Mapeo](https://mapeo.app/)), you can use a Node command line tool called `tl` to conver them to `MBTiles`: [guide](https://github.com/mojodna/tl).
+* If you already have tiles in a different format (like in the `tilelive-file` used by [Mapeo](https://mapeo.app/)), you can use a Node command line tool called `tl` to convert them to `MBTiles`. Please see our [Mapeo maps to Terrastories guide](MAPEO-MAPS-IN-TERRASTORIES.md).
 
 Once generated, place the `MBTiles` in the `tileserver/data/mbtiles/` directory, with the right filename as referenced by `style.json`.
 

--- a/tileserver/data/styles/style.json
+++ b/tileserver/data/styles/style.json
@@ -18,8 +18,8 @@
             "type": "vector"
         }
      },
-     "sprite": "sprites",
-     "glyphs": "fonts/{fontstack}/{range}.pbf",
+     "sprite": "sprite",
+     "glyphs": "{fontstack}/{range}.pbf",
      "layers": [
          {
              "id": "background",


### PR DESCRIPTION
This is fixing a very old issue: https://github.com/Terrastories/terrastories/issues/85 and also adding documentation for getting offline Mapeo maps (XYZ tiles) converted into MBTiles for usage in Terrastories.