### PR TITLE
Fix: build && JS compressor

### DIFF
--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -15,7 +15,7 @@ gem 'rgeo-geojson'
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'
 # Use Uglifier as compressor for JavaScript assets
-gem 'uglifier', '>= 1.3.0'
+gem 'terser'
 # See https://github.com/rails/execjs#readme for more supported runtimes
 gem 'acts-as-taggable-on', '~> 5.0'
 

--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -17,7 +17,6 @@ gem 'sass-rails', '~> 5.0'
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '>= 1.3.0'
 # See https://github.com/rails/execjs#readme for more supported runtimes
-gem 'mini_racer', platforms: :ruby
 gem 'acts-as-taggable-on', '~> 5.0'
 
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder

--- a/rails/Gemfile.lock
+++ b/rails/Gemfile.lock
@@ -71,7 +71,7 @@ GEM
       rake (>= 10.4, < 14.0)
     arel (9.0.0)
     aws-eventstream (1.2.0)
-    aws-partitions (1.499.0)
+    aws-partitions (1.501.0)
     aws-sdk-core (3.121.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
@@ -184,7 +184,6 @@ GEM
       activerecord
       kaminari-core (= 1.2.1)
     kaminari-core (1.2.1)
-    libv8-node (15.14.0.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -202,8 +201,6 @@ GEM
     mini_magick (4.11.0)
     mini_mime (1.1.1)
     mini_portile2 (2.6.1)
-    mini_racer (0.4.0)
-      libv8-node (~> 15.14.0.0)
     minitest (5.14.4)
     momentjs-rails (2.20.1)
       railties (>= 3.1)
@@ -404,7 +401,6 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   mapbox-gl-rails
   mini_magick (~> 4.8)
-  mini_racer
   pg (>= 0.18, < 2.0)
   plyr-rails
   pry-rails

--- a/rails/Gemfile.lock
+++ b/rails/Gemfile.lock
@@ -344,13 +344,13 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    terser (1.1.6)
+      execjs (>= 0.3.0, < 3)
     thor (1.1.0)
     thread_safe (0.3.6)
     tilt (2.0.10)
     tzinfo (1.2.9)
       thread_safe (~> 0.1)
-    uglifier (4.2.0)
-      execjs (>= 0.3.0, < 3)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (3.7.0)
@@ -418,8 +418,8 @@ DEPENDENCIES
   simplecov
   spring
   spring-watcher-listen (~> 2.0.0)
+  terser
   tzinfo-data
-  uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
   webdrivers
   webpacker (~> 3.5)

--- a/rails/config/environments/production.rb
+++ b/rails/config/environments/production.rb
@@ -25,7 +25,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = Uglifier.new(harmony: true)
+  config.assets.js_compressor = :terser
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
This removes the gem `mini_racer` which provided a libv8 runtime to compile and compress JS using Uglifier.

These are remants from the before webpacker and NodeJS were commonplace in Rails.

Since we're still compiling assets, we need some way to compress. After some research, it looks like `mini_racer` is out since we have NodeJS, and `uglifier` recommended `terser-ruby` for ES6 support.

I tested this by deploying the app to staging manually from this branch and noting that the build is fixed. I also clicked around in the app to make sure the map, filters, and functions still behave as expected.