### PR TITLE
Change order of fields in Edit mode

### DIFF
--- a/rails/app/dashboards/place_dashboard.rb
+++ b/rails/app/dashboards/place_dashboard.rb
@@ -54,13 +54,13 @@ class PlaceDashboard < Administrate::BaseDashboard
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = [
     :name,
+    :photo,
     :description,
     :type_of_place,
     :region,
-    :long,
-    :lat,
     :stories,
-    :photo,
+    :lat,
+    :long,
   ].freeze
 
   # Overwrite this method to customize how places are displayed

--- a/rails/app/dashboards/speaker_dashboard.rb
+++ b/rails/app/dashboards/speaker_dashboard.rb
@@ -50,12 +50,12 @@ class SpeakerDashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = [
-    :photo,
     :name,
-    :stories,
+    :photo,
+    :speaker_community,
     :birthdate,
     :birthplace,
-    :speaker_community,
+    :stories,
   ].freeze
 
   # Overwrite this method to customize how speakers are displayed

--- a/rails/app/dashboards/story_dashboard.rb
+++ b/rails/app/dashboards/story_dashboard.rb
@@ -65,12 +65,12 @@ class StoryDashboard < Administrate::BaseDashboard
     :desc,
     :language,
     :topic,
+    :media,
     :speakers,
+    :places,
     :interview_location,
     :interviewer,
     :date_interviewed,
-    :places,
-    :media,
     :permission_level
   ].freeze
 

--- a/rails/config/locales/en/administrate.en.yml
+++ b/rails/config/locales/en/administrate.en.yml
@@ -15,6 +15,9 @@ en:
           user_only: "Member"
           editor_only: "Editor"
           admin_only: "Admin"
+      place:
+        lat: Latitude
+        long: Longitude
   administrate:
     actions:
       confirm: Are you sure?


### PR DESCRIPTION
[Issue #652](https://github.com/Terrastories/terrastories/issues/652)

This PR includes:
Changes in the order of the fields in the Edit view for Speakers, Stories, and Places

![Screen Shot 2021-10-03 at 8 32 36 PM (2)](https://user-images.githubusercontent.com/50844569/135791132-ec8bc525-ae64-4756-a557-9aa9b87a9013.png)
![Screen Shot 2021-10-03 at 8 32 53 PM (2)](https://user-images.githubusercontent.com/50844569/135791153-811a8b78-8d88-4931-b7a0-338a9251b7a2.png)
![Screen Shot 2021-10-03 at 8 32 06 PM (2)](https://user-images.githubusercontent.com/50844569/135791170-d8d940bb-08c2-4699-aaf4-2a9df02bbebb.png)
