### PR TITLE
Fix display of story elements in sidebar

### DIFF
--- a/rails/app/javascript/components/Story.jsx
+++ b/rails/app/javascript/components/Story.jsx
@@ -24,7 +24,7 @@ const Story = props => {
           {
             speakers.map(speaker => {
               return speaker.name
-            }).join(',')
+            }).join(', ')
           }
         </p>
       </div>
@@ -45,8 +45,8 @@ const Story = props => {
         </div>
         <div className="container">
           <h6 className="title">
-            {story.permission_level === "restricted" && "🔒"}
             {story.title}
+            {story.permission_level === "restricted" && " 🔒"}            
           </h6>
           <p>{story.desc}</p>
           {


### PR DESCRIPTION
Resolves https://github.com/Terrastories/terrastories/issues/665

Moves the 🔒 after the title of the story (and precedes it with a space), and adds a space after the comma separating speakers.

![image](https://user-images.githubusercontent.com/31662219/136128306-3db62bc0-1e88-4942-9f8d-8d5c90771f30.png)
