### PR TITLE
664: Fix the display of marker popup content

### DIFF
--- a/rails/app/assets/stylesheets/components/_balloon.scss
+++ b/rails/app/assets/stylesheets/components/_balloon.scss
@@ -24,6 +24,14 @@
     }
   }
 
+  &-label {
+    font-weight: bold!important;
+  }
+
+  &-description {
+    margin: 10px 0;
+  }
+
   .mapboxgl-popup-content {
     h1, h2, h3, h4, h5, p, img {
       margin: 0;

--- a/rails/app/javascript/components/Popup.jsx
+++ b/rails/app/javascript/components/Popup.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 const Popup = (props) => {
-  const { id, name, photo_url, region, type_of_place } = props.feature.properties;
+  const { id, name, photo_url, description, region, type_of_place } = props.feature.properties;
   
   return (
     <div id={`popup-${id}`}>
@@ -11,10 +11,9 @@ const Popup = (props) => {
       </div>
       <div className="ts-markerPopup-content">
         {photo_url !== "null" && (<img src={photo_url} />)}
-        {region || type_of_place && <div>
-          {region !== "null" && <div>Region: {region} </div>}
-          {type_of_place !== "null" && <div>Type of Place: {type_of_place} </div>}
-        </div> }
+        {description !== "" && (<div class={`ts-markerPopup-description`}>{description}</div>)}
+        {region !== "" && (<div><span class="ts-markerPopup-label">Region:</span> {region}</div>)}
+        {type_of_place !== "" && (<div>Type of Place: {type_of_place}</div>)}
       </div>
     </div>
   );

--- a/rails/app/javascript/components/Popup.jsx
+++ b/rails/app/javascript/components/Popup.jsx
@@ -13,7 +13,7 @@ const Popup = (props) => {
         {photo_url !== "null" && (<img src={photo_url} />)}
         {description !== "" && (<div class={`ts-markerPopup-description`}>{description}</div>)}
         {region !== "" && (<div><span class="ts-markerPopup-label">Region:</span> {region}</div>)}
-        {type_of_place !== "" && (<div>Type of Place: {type_of_place}</div>)}
+        {type_of_place !== "" && (<div><span class="ts-markerPopup-label">Type of Place:</span> {type_of_place}</div>)}
       </div>
     </div>
   );

--- a/rails/app/javascript/components/Story.jsx
+++ b/rails/app/javascript/components/Story.jsx
@@ -24,7 +24,7 @@ const Story = props => {
           {
             speakers.map(speaker => {
               return speaker.name
-            }).join(',')
+            }).join(', ')
           }
         </p>
       </div>
@@ -45,8 +45,8 @@ const Story = props => {
         </div>
         <div className="container">
           <h6 className="title">
-            {story.permission_level === "restricted" && "🔒"}
             {story.title}
+            {story.permission_level === "restricted" && " 🔒"}
           </h6>
           <p>{story.desc}</p>
           {


### PR DESCRIPTION
Resolves https://github.com/Terrastories/terrastories/issues/664

Exposes `description` to geojson, and adds it to the marker popup.
Sets conditions to check for empty content on all three fields `description`, `region,`, and `type of place`, and renders with bolded labels in the case of the last two.

![image](https://user-images.githubusercontent.com/31662219/136130902-ee6f97f8-0593-4a00-baa1-db4d9c890ea2.png)
