### PR TITLE
Change primary filter to alphabetical order

### DIFF
--- a/rails/app/javascript/components/App.jsx
+++ b/rails/app/javascript/components/App.jsx
@@ -71,7 +71,7 @@ class App extends Component {
     let filterMap = {};
     FILTER_CATEGORIES.map(category => {
       switch (category) {
-        case FILTER_CATEGORIES[0]: {
+        case I18n.t("region"): {
           // first category: Region
           const regionSet = new Set(
             this.props.stories
@@ -83,7 +83,7 @@ class App extends Component {
           filterMap[category] = Array.from(regionSet).sort();
           break;
         }
-        case FILTER_CATEGORIES[1]: {
+        case I18n.t("place_type"): {
           // second category: Type of Place
           const typeOfPlaceSet = new Set(
             this.props.stories
@@ -97,7 +97,7 @@ class App extends Component {
           filterMap[category] = Array.from(typeOfPlaceSet).sort();
           break;
         }
-        case FILTER_CATEGORIES[2]: {
+        case I18n.t("speaker"): {
           // third category: Speaker
           const speakerSet = new Set(
             this.props.stories
@@ -109,7 +109,7 @@ class App extends Component {
           filterMap[category] = Array.from(speakerSet).sort();
           break;
         }
-        case FILTER_CATEGORIES[3]: {
+        case I18n.t("topic"): {
           // second category: Topic
           const topicSet = new Set(
             this.props.stories
@@ -127,7 +127,7 @@ class App extends Component {
   handleFilter = (category, item) => {
     let filteredStories = [];
     switch (category) {
-      case FILTER_CATEGORIES[0]: {
+      case I18n.t("region"): {
         // first category: region
         filteredStories = this.props.stories.filter(story => {
           if (
@@ -143,7 +143,7 @@ class App extends Component {
         });
         break;
       }
-      case FILTER_CATEGORIES[1]: {
+      case I18n.t("place_type"): {
         // second category: type of places
         filteredStories = this.props.stories.filter(story => {
           if (
@@ -160,7 +160,7 @@ class App extends Component {
         });
         break;
       }
-      case FILTER_CATEGORIES[2]: {
+      case I18n.t("speaker"): {
         // third category: speaker name
         filteredStories = this.props.stories.filter(story => {
           if (
@@ -176,7 +176,7 @@ class App extends Component {
         });
         break;
       }
-      case FILTER_CATEGORIES[3]: {
+      case I18n.t("topic"): {
         // fourth category: topic
         filteredStories = this.props.stories.filter(story => {
             if (story.topic) {

--- a/rails/app/javascript/constants/FilterConstants.js
+++ b/rails/app/javascript/constants/FilterConstants.js
@@ -1,3 +1,3 @@
 /* global I18n */
 
-export default [I18n.t("region"), I18n.t("place_type"), I18n.t("speaker"),  I18n.t("topic")];
+export default [I18n.t("region"), I18n.t("place_type"), I18n.t("speaker"),  I18n.t("topic")].sort();


### PR DESCRIPTION
Issue #672 

This PR includes:
- Sorted array in `FilterConstants`
- Modified access to above array by adding proper element to switch case, instead of using array index. By doing this, order of cases in the switch won't matter.
<img width="1280" alt="Screen Shot 2021-10-10 at 10 30 49 AM" src="https://user-images.githubusercontent.com/50844569/136706812-ee43ee19-b261-4d98-b306-e1e36ac3714f.png">
