### PR TITLE
Adapt height of the welcome screen card to adjust to overflow content

### DIFF
--- a/rails/app/assets/stylesheets/components/welcome.scss
+++ b/rails/app/assets/stylesheets/components/welcome.scss
@@ -158,8 +158,4 @@
     font-size: 3.1vw;
   }
 }
-// @media screen and (max-width:450px){
-//   .welcome-card{
-//     min-height: 15rem;
-//   }
-// }
+


### PR DESCRIPTION
Fixes #684 

### What I did: 

1. The height is no longer fixed , it dynamic changes as the screen size decreases, I have set a min-height property which also solves the overflowing content issue (no longer overflows anymore)
2. All the content of the card appears in a single line upto 355px. Added some media queries with dynamic font-sizing.


### Here's a screenshot for 437px (no overflow of content , no forced two lines anymore) : 
![ss](https://user-images.githubusercontent.com/77877486/137628382-134b5cce-382f-44d1-9094-6e240df9ef2c.png)


