### PR TITLE
Fixing extension field in compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,14 @@
 version: "3.7"
+
+x-web-common: &x-web-common
+  image: ${DOCKER_IMAGE_NAME:-terrastories}
+  build:
+    context: ./rails
+    args:
+      precompileassets: "not"
+  env_file:
+    - .env
+
 services:
   db:
     image: postgres:11
@@ -16,15 +26,6 @@ services:
   #     - ./rails:/opt/terrastories:cached
   #   ports:
   #     - 3035:3035
-
-  x-web-common: &x-web-common
-    image: ${DOCKER_IMAGE_NAME-terrastories}
-    build:
-      context: ./rails
-      args:
-        precompileassets: "not"
-    env_file:
-      - .env
 
   web:
     <<: *x-web-common


### PR DESCRIPTION
Extension fields (`x-*`) need to be at the top level of the compose file. Also the syntax for default variables is `${VAR:-default}` (added the missing colon).

Fixes #695 

Signed-off-by: Brandon Mitchell <git@bmitch.net>