### PR TITLE
581 theme validation for data fields

### DIFF
--- a/rails/app/models/theme.rb
+++ b/rails/app/models/theme.rb
@@ -6,8 +6,8 @@ class Theme < ApplicationRecord
 
   validates :background_img, blob: { content_type: ['image/png', 'image/jpg', 'image/jpeg'] }
   validates :sponsor_logos, blob: { content_type: ['image/png', 'image/jpg', 'image/jpeg'], size_range: 1..5.megabytes }
-  validates :mapbox_access_token, :presence =>  {:message => 'is required when mapbox style URL is set'}, unless: -> { mapbox_style_url.blank? }
-  validates :mapbox_style_url, :presence => {:message => 'is required when mapbox access token is set'}, unless: -> { mapbox_access_token.blank? }
+  validates :mapbox_access_token, :presence =>  {:message => 'is required when the Mapbox style URL is set.'}, unless: -> { mapbox_style_url.blank? }
+  validates :mapbox_style_url, :presence => {:message => 'is required when the Mapbox access token is set.'}, unless: -> { mapbox_access_token.blank? }
   validates :center_lat, :sw_boundary_lat, :ne_boundary_lat,
     :numericality=> true, allow_nil: true, :inclusion => {:in => -90..90, :message => "value should be between -90 and 90"}
   validates :bearing, :center_long, :sw_boundary_long, :ne_boundary_long,


### PR DESCRIPTION
Fixes issue #581 

The user is now required to input a mapbox access token if the user wishes to update the map box style url and vice- versa

### Screenshots
![WhatsApp Image 2021-10-20 at 07 41 21](https://user-images.githubusercontent.com/77877486/138017197-a02460b9-2a0c-4518-b013-c1cc0b5b86e9.jpeg)  
![WhatsApp Image 2021-10-20 at 07 41 39](https://user-images.githubusercontent.com/77877486/138017205-177ba377-c0fd-4783-bd73-d91cd88ecf37.jpeg)


