### PR TITLE
Add 3D Terrain toggle for online maps

### DIFF
--- a/documentation/CUSTOMIZATION.md
+++ b/documentation/CUSTOMIZATION.md
@@ -26,7 +26,9 @@ _**Note:** when using Mapbox.com maps with Terrastories, you are subject to Mapb
 
 ### Map extent, zoom, pitch, boundaries, and 3D Terrain
 
-It is possible to set a custom map extent, zoom level, pitch, and boundaries of the Terrastories map. Additionally, for online Terrastories maps, you can activate a realistic 3D Terrain layer to view your maps in 3D. This can be done in the Terrastories `Theme` menu for a community when logged in as a user with admin permissions.
+It is possible to set a custom map extent, zoom level, pitch, and boundaries of the Terrastories map. Additionally, for online Terrastories maps, you can toggle on/off a realistic Mapbox 3D Terrain layer to view your maps in 3D. 3D Terrain adds another level of detail to the landscape, but requires more map and tile loading and therefore can impact the overall performance of Terrastories on your device.
+
+Setting these map properties can be done in the Terrastories `Theme` menu for a community when logged in as a user with admin permissions.
 ## Adding languages to Terrastories
 
 Terrastories uses internationalization to translate the application's core text, like the welcome page, sidebar, and administrative back end content. We have made it easy to add new languages to a Terrastories server without needing to touch any of the code.

--- a/documentation/CUSTOMIZATION.md
+++ b/documentation/CUSTOMIZATION.md
@@ -24,9 +24,9 @@ For offline "Field Kit" usage of Terrastories, you need to supply your own map t
 
 _**Note:** when using Mapbox.com maps with Terrastories, you are subject to Mapbox's [pricing schema](https://www.mapbox.com/pricing/) which has a free tier of up to 50,000 map loads per month. If you anticipate more monthly loads than that, you can get in touch with Mapbox's community team at community@mapbox.com to see what they can do to help._
 
-### Map extent and zoom
+### Map extent, zoom, pitch, boundaries, and 3D Terrain
 
-It is possible to set a custom map extent, zoom level, and boundaries of the Terrastories map. This can be done in the Terrastories `Theme` menu for a community when logged in as a user with admin permissions.
+It is possible to set a custom map extent, zoom level, pitch, and boundaries of the Terrastories map. Additionally, for online Terrastories maps, you can activate a realistic 3D Terrain layer to view your maps in 3D. This can be done in the Terrastories `Theme` menu for a community when logged in as a user with admin permissions.
 ## Adding languages to Terrastories
 
 Terrastories uses internationalization to translate the application's core text, like the welcome page, sidebar, and administrative back end content. We have made it easy to add new languages to a Terrastories server without needing to touch any of the code.

--- a/rails/app/dashboards/theme_dashboard.rb
+++ b/rails/app/dashboards/theme_dashboard.rb
@@ -15,6 +15,7 @@ class ThemeDashboard < Administrate::BaseDashboard
     sponsor_logos: Field::ActiveStorage.with_options({destroy_path: :admin_themes_path}),
     mapbox_style_url: Field::String,
     mapbox_access_token: Field::String,
+    mapbox_3d: Field::Boolean,
     center_lat: Field::Number,
     center_long: Field::Number,
     sw_boundary_lat: Field::Number,
@@ -44,6 +45,7 @@ class ThemeDashboard < Administrate::BaseDashboard
   sponsor_logos
   mapbox_style_url
   mapbox_access_token
+  mapbox_3d
   center_lat
   center_long
   sw_boundary_lat
@@ -63,6 +65,7 @@ class ThemeDashboard < Administrate::BaseDashboard
   sponsor_logos
   mapbox_style_url
   mapbox_access_token
+  mapbox_3d
   center_lat
   center_long
   sw_boundary_lat

--- a/rails/app/javascript/components/App.jsx
+++ b/rails/app/javascript/components/App.jsx
@@ -29,6 +29,7 @@ class App extends Component {
     use_local_map_server: PropTypes.bool,
     mapbox_access_token: PropTypes.string,
     mapbox_style: PropTypes.string,
+    mapbox_3d: PropTypes.bool,
     logo_path: PropTypes.string,
     user: PropTypes.object,
     center_lat: PropTypes.string,
@@ -41,6 +42,8 @@ class App extends Component {
     pitch: PropTypes.number,
     bearing: PropTypes.string
   };
+
+
 
   componentDidMount() {
     const points = this.getPointsFromStories(this.state.stories);
@@ -346,6 +349,7 @@ class App extends Component {
           mapboxAccessToken={this.props.mapbox_access_token}
           useLocalMapServer={this.props.use_local_map_server}
           mapboxStyle={this.props.mapbox_style}
+          mapbox3d={this.props.mapbox_3d}
           clearFilteredStories={this.resetStoriesAndMap}
           onMapPointClick={this.handleMapPointClick}
           activePoint={this.state.activePoint}

--- a/rails/app/javascript/components/Map.jsx
+++ b/rails/app/javascript/components/Map.jsx
@@ -23,6 +23,7 @@ export default class Map extends Component {
     onMapPointClick: PropTypes.func,
     mapboxStyle: PropTypes.string,
     mapboxAccessToken: PropTypes.string,
+    mapbox3d: PropTypes.bool,
     useLocalMapServer: PropTypes.bool,
     markerImgUrl: PropTypes.string,
   };
@@ -57,27 +58,28 @@ export default class Map extends Component {
           "icon-allow-overlap": true
         }
       });
-
-      this.map.addSource('mapbox-dem', {
-        'type': 'raster-dem',
-        'url': 'mapbox://mapbox.mapbox-terrain-dem-v1',
-        'tileSize': 512,
-        'maxzoom': 14
+      if(this.props.mapbox3d) {
+        this.map.addSource('mapbox-dem', {
+          'type': 'raster-dem',
+          'url': 'mapbox://mapbox.mapbox-terrain-dem-v1',
+          'tileSize': 512,
+          'maxzoom': 14
         });
-
-      // add the DEM source as a terrain layer with exaggerated height
-      this.map.setTerrain({ 'source': 'mapbox-dem', 'exaggeration': 1.5 });
-         
-      // add a sky layer that will show when the map is highly pitched
-      this.map.addLayer({
-        'id': 'sky',
-        'type': 'sky',
-        'paint': {
-        'sky-type': 'atmosphere',
-        'sky-atmosphere-sun': [0.0, 0.0],
-        'sky-atmosphere-sun-intensity': 15
-        }
-      });
+    
+        // add the DEM source as a terrain layer with exaggerated height
+        this.map.setTerrain({ 'source': 'mapbox-dem', 'exaggeration': 1.5 });
+          
+        // add a sky layer that will show when the map is highly pitched
+        this.map.addLayer({
+          'id': 'sky',
+          'type': 'sky',
+          'paint': {
+          'sky-type': 'atmosphere',
+          'sky-atmosphere-sun': [0.0, 0.0],
+          'sky-atmosphere-sun-intensity': 15
+          }
+        });
+      }
 
       this.addHomeButton();
 

--- a/rails/app/javascript/components/Map.jsx
+++ b/rails/app/javascript/components/Map.jsx
@@ -58,7 +58,7 @@ export default class Map extends Component {
           "icon-allow-overlap": true
         }
       });
-      if(this.props.mapbox3d) {
+      if(!this.props.useLocalMapServer && this.props.mapbox3d) {
         this.map.addSource('mapbox-dem', {
           'type': 'raster-dem',
           'url': 'mapbox://mapbox.mapbox-terrain-dem-v1',

--- a/rails/app/javascript/components/Map.jsx
+++ b/rails/app/javascript/components/Map.jsx
@@ -58,6 +58,27 @@ export default class Map extends Component {
         }
       });
 
+      this.map.addSource('mapbox-dem', {
+        'type': 'raster-dem',
+        'url': 'mapbox://mapbox.mapbox-terrain-dem-v1',
+        'tileSize': 512,
+        'maxzoom': 14
+        });
+
+      // add the DEM source as a terrain layer with exaggerated height
+      this.map.setTerrain({ 'source': 'mapbox-dem', 'exaggeration': 1.5 });
+         
+      // add a sky layer that will show when the map is highly pitched
+      this.map.addLayer({
+        'id': 'sky',
+        'type': 'sky',
+        'paint': {
+        'sky-type': 'atmosphere',
+        'sky-atmosphere-sun': [0.0, 0.0],
+        'sky-atmosphere-sun-intensity': 15
+        }
+      });
+
       this.addHomeButton();
 
       // Attaches popups + events

--- a/rails/app/models/theme.rb
+++ b/rails/app/models/theme.rb
@@ -30,6 +30,7 @@ end
 #  center_long         :decimal(10, 6)
 #  mapbox_access_token :string
 #  mapbox_style_url    :string
+#  mapbox_3d           :boolean          default(FALSE), not null
 #  ne_boundary_lat     :decimal(10, 6)
 #  ne_boundary_long    :decimal(10, 6)
 #  pitch               :decimal(10, 6)

--- a/rails/app/views/home/_home.json.jbuilder
+++ b/rails/app/views/home/_home.json.jbuilder
@@ -26,6 +26,7 @@ json.logo_path image_path("logocombo.svg")
 json.user current_user
 json.mapbox_access_token mapbox_token
 json.mapbox_style mapbox_style
+json.mapbox_3d @theme.mapbox_3d
 json.use_local_map_server local_mapbox?
 json.center_lat @theme.center_lat
 json.center_long @theme.center_long

--- a/rails/config/locales/en/administrate.en.yml
+++ b/rails/config/locales/en/administrate.en.yml
@@ -28,7 +28,7 @@ en:
         sponsor_logos: Sponsor logos (for welcome screen)
         mapbox_style_url: Mapbox style URL (for online maps)
         mapbox_access_token: Mapbox access token associated with the style
-        mapbox_3d: Activate 3D Terrain view for map
+        mapbox_3d: Activate 3D Terrain view for online map
         center_lat: Map center, latitude
         center_long: Map center, longitude
         sw_boundary_lat: SW bounding box, latitude

--- a/rails/config/locales/en/administrate.en.yml
+++ b/rails/config/locales/en/administrate.en.yml
@@ -28,6 +28,7 @@ en:
         sponsor_logos: Sponsor logos (for welcome screen)
         mapbox_style_url: Mapbox style URL (for online maps)
         mapbox_access_token: Mapbox access token associated with the style
+        mapbox_3d: Activate 3D Terrain view for map
         center_lat: Map center, latitude
         center_long: Map center, longitude
         sw_boundary_lat: SW bounding box, latitude

--- a/rails/db/migrate/20220414120430_add_mapbox_3d_boolean.rb
+++ b/rails/db/migrate/20220414120430_add_mapbox_3d_boolean.rb
@@ -1,0 +1,5 @@
+class AddMapbox3dBoolean < ActiveRecord::Migration[6.0]
+  def change
+    add_column :themes, :mapbox_3d, :boolean, default: false
+  end
+end

--- a/rails/db/schema.rb
+++ b/rails/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_08_171359) do
+ActiveRecord::Schema.define(version: 2022_04_14_120430) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -127,6 +127,7 @@ ActiveRecord::Schema.define(version: 2022_04_08_171359) do
     t.datetime "updated_at", null: false
     t.string "mapbox_style_url"
     t.string "mapbox_access_token"
+    t.boolean "mapbox_3d", default: false
     t.decimal "center_lat", precision: 10, scale: 6
     t.decimal "center_long", precision: 10, scale: 6
     t.decimal "sw_boundary_lat", precision: 10, scale: 6


### PR DESCRIPTION
Closes https://github.com/Terrastories/terrastories/issues/618.

This PR adds a new feature to turn 3d Terrain for Mapbox.com maps on and off. Mapbox's 3D terrain is a new, realistic 3D exaggeration layer based on a digital elevation model, and adds another level of detail to the landscape and where stories may be found. It can however be a performance hog, so it will be best to allow our users to decide whether they want this feature activated or not. This PR makes it possible to do so for an admin user, by creating a boolean in the Theme model and menu. 

* `mapbox_3d` boolean added to Theme model.
* On the React side, if `mapbox_3d` is activated, then the map will render in 3d.

In the future we could explore having this be a setting per user instead of per community, but I think it would be good to get some user input on this decision and the feature as a whole.

![image](https://user-images.githubusercontent.com/31662219/163464627-2715e109-950d-4f0f-bae0-027fd24cdf61.png)

3d Terrain activated:
![image](https://user-images.githubusercontent.com/31662219/163464889-765d22d5-067d-47ee-a675-5195cb63aaea.png)

3d Terrain de-activated:
![image](https://user-images.githubusercontent.com/31662219/163465009-02573685-4865-423f-891f-c8fafad1d5a9.png)