### PR TITLE
Quick page title fix for Administrate views

### DIFF
--- a/rails/app/views/layouts/admin/application.html.erb
+++ b/rails/app/views/layouts/admin/application.html.erb
@@ -19,7 +19,7 @@ By default, it renders:
   <meta name="ROBOTS" content="NOODP">
   <meta name="viewport" content="initial-scale=1">
   <title>
-    <%= content_for(:title) %> - <%= application_title %>
+    <%= content_for(:title) %> - Terrastories
   </title>
   <%= render "stylesheet" %>
   <%= stylesheet_pack_tag 'admin' %>


### PR DESCRIPTION
It won't be possible to do a more robust rewrite of our title tags ala https://github.com/Terrastories/terrastories/discussions/760 but this is a quick fix for Administrate views.