### PR TITLE
Add right margin to popup close button

### DIFF
--- a/rails/app/assets/stylesheets/components/_balloon.scss
+++ b/rails/app/assets/stylesheets/components/_balloon.scss
@@ -16,6 +16,7 @@
     &-button {
       align-self: flex-start;
       margin-top: 6px;
+      margin-right: 6px;
       font-size: 15px;
       background: none;
       border: none;


### PR DESCRIPTION
Fixes an issue where the right margin of the popup close button was misaligned.

![image](https://user-images.githubusercontent.com/31662219/166394853-4f0d1692-ebf7-42ac-b2c3-73fb5268bc56.png)
