### PR TITLE
Force SSL for production server

### DIFF
--- a/rails/config/environments/production.rb
+++ b/rails/config/environments/production.rb
@@ -47,7 +47,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
This PR sets `config.force_ssl = true` for production Terrastories servers, which is desirable for the Terrastories-maintained our.terrastories.io server, and for third party services that may choose to deactivate this on their own if they don't want SSL.

I verified that currently, offline Terrastories is not loading the production environment.
```
[16] pry(main)> Rails.env.production?
=> false
[17] pry(main)> Rails.env.development?
=> true
```