### PR TITLE
fix text overflow in story card and marker popup

### DIFF
--- a/rails/app/assets/stylesheets/components/_balloon.scss
+++ b/rails/app/assets/stylesheets/components/_balloon.scss
@@ -25,12 +25,17 @@
     }
   }
 
+  &-tag {
+    overflow-wrap: break-word;
+  }
+
   &-label {
     font-weight: bold !important;
   }
 
   &-description {
     margin: 10px 0;
+    overflow-wrap: break-word;
   }
 
   &-audio {
@@ -45,6 +50,8 @@
 
     h1 {
       text-align: center;
+      overflow-wrap: break-word;
+      overflow: auto;
       font-weight: 400;
       font-size: 1.2rem;
       line-height: 1.25;

--- a/rails/app/assets/stylesheets/components/card.scss
+++ b/rails/app/assets/stylesheets/components/card.scss
@@ -160,8 +160,12 @@ $el-shadow: 0 1px 4px $lighter-gray;
           background-color: $light-gray;
         }
       }
+      .title {
+        overflow-wrap: break-word;
+      }
       p {
         font-size: 0.85rem;
+        overflow-wrap: break-word;
         line-height: 1.25;
         margin-top: 1rem;
         @include ui-font;

--- a/rails/app/javascript/components/Popup.jsx
+++ b/rails/app/javascript/components/Popup.jsx
@@ -17,8 +17,8 @@ const Popup = (props) => {
                                                       controlsList="nodownload"
                                                       src={name_audio_url}> </audio></div>)}
         {description && (<div className="ts-markerPopup-description">{description}</div>)}
-        {region && (<div><span className="ts-markerPopup-label">{I18n.t("region")}:</span> {region}</div>)}
-        {type_of_place && (<div><span className="ts-markerPopup-label">{I18n.t("place_type")}:</span> {type_of_place}</div>)}
+        {region && (<div className="ts-markerPopup-tag"><span className="ts-markerPopup-label">{I18n.t("region")}:</span> {region}</div>)}
+        {type_of_place && (<div className="ts-markerPopup-tag"><span className="ts-markerPopup-label">{I18n.t("place_type")}:</span> {type_of_place}</div>)}
       </div>
     </div>
   );


### PR DESCRIPTION
Closes https://github.com/Terrastories/terrastories/issues/787. 

![image](https://user-images.githubusercontent.com/31662219/181569150-d214f020-df5f-4ca4-be4a-0c662bacf829.png)

This PR fixes text overflow issues on the map interface. Various strings were not set to overflow properly as seen in the issue screenshot.