### PR TITLE
Fix: Error with Importable header mismatch rescue

### DIFF
--- a/rails/app/assets/stylesheets/cms/_flash.scss
+++ b/rails/app/assets/stylesheets/cms/_flash.scss
@@ -15,6 +15,8 @@ span.flash {
   border: 1px solid $dark-green;
   opacity: 1;
 
+  max-width: 30vw;
+
   &.flash-notice {
     background-color: lighten($dark-blue, 60%);
     border-color: $dark-blue;

--- a/rails/app/controllers/dashboard/imports_controller.rb
+++ b/rails/app/controllers/dashboard/imports_controller.rb
@@ -1,6 +1,6 @@
 module Dashboard
   class ImportsController < ApplicationController
-    rescue_from FileImporter::HeaderMismatchError, with: :mapped_header_mismatch
+    rescue_from Importable::FileImporter::HeaderMismatchError, with: :mapped_header_mismatch
     def show
 
     end
@@ -55,7 +55,7 @@ module Dashboard
     end
 
     def mapped_header_mismatch
-      flash.alert = "Header Mismatch"
+      flash.alert = "Additional headers detected. Please verify your CSV headers against the resource you are importing."
       redirect_to import_path
     end
   end


### PR DESCRIPTION
Fixes error on Heroku boot:
```
app/controllers/dashboard/imports_controller.rb:3:in <class:ImportsController>': uninitialized constant Dashboard::ImportsController::FileImporter (NameError)
```