### PR TITLE
Fix: Places desc textarea should match width

### DIFF
--- a/rails/app/assets/stylesheets/cms/_forms.scss
+++ b/rails/app/assets/stylesheets/cms/_forms.scss
@@ -4,7 +4,9 @@ form.form {
   &.aligned {
     width: 50%;
 
-    input:not([type=checkbox]):not([type=submit]), select {
+    input:not([type=checkbox]):not([type=submit]),
+    select,
+    textarea {
       width: 100%;
     }
   }

--- a/rails/app/views/dashboard/places/_form.html.erb
+++ b/rails/app/views/dashboard/places/_form.html.erb
@@ -8,7 +8,7 @@
   <%= f.file_field :name_audio %>
 
   <%= f.label :description %>
-  <%= f.text_area :description %>
+  <%= f.text_area :description, rows: 3 %>
 
   <% if @place.name_audio.attached? %>
   <ul class="filename-list">


### PR DESCRIPTION
Adds `textarea` to `aligned` forms to ensure width matches other inputs. This also ensures text area starts at 3 rows.