### PR TITLE
Fix: Allow lat/long values to accept any valid latitude or longitude value

### DIFF
--- a/rails/app/views/dashboard/places/_form.html.erb
+++ b/rails/app/views/dashboard/places/_form.html.erb
@@ -36,10 +36,10 @@
   </div>
 
   <%= f.label :lat %>
-  <%= f.number_field :lat, step: "0.00001", min: -90, max: 90 %>
+  <%= f.text_field :lat %>
 
   <%= f.label :long %>
-  <%= f.number_field :long, step: "0.00001", min: -180, max: 180 %>
+  <%= f.text_field :long %>
 
   <%= f.submit %>
 <% end %>

--- a/rails/app/views/dashboard/places/_form.html.erb
+++ b/rails/app/views/dashboard/places/_form.html.erb
@@ -36,10 +36,10 @@
   </div>
 
   <%= f.label :lat %>
-  <%= f.number_field :lat %>
+  <%= f.number_field :lat, step: "0.00001", min: -90, max: 90 %>
 
   <%= f.label :long %>
-  <%= f.number_field :long %>
+  <%= f.number_field :long, step: "0.00001", min: -180, max: 180 %>
 
   <%= f.submit %>
 <% end %>

--- a/rails/app/views/dashboard/themes/edit.html.erb
+++ b/rails/app/views/dashboard/themes/edit.html.erb
@@ -79,23 +79,23 @@
             <label><%= t("map.sw_corner") %></label>
             <div class="input-group">
               <%= f.label :sw_boundary_lat %>
-              <%= f.number_field :sw_boundary_lat, optional: true, value: @theme.sw_boundary_lat %>
+              <%= f.text_field :sw_boundary_lat, optional: true, value: @theme.sw_boundary_lat %>
             </div>
             <div class="input-group">
               <%= f.label :sw_boundary_long %>
-              <%= f.number_field :sw_boundary_long, optional: true, value: @theme.sw_boundary_long %>
+              <%= f.text_field :sw_boundary_long, optional: true, value: @theme.sw_boundary_long %>
             </div>
           </div>
           <div>
             <label><%= t("map.ne_corner") %></label>
             <div class="input-group">
               <%= f.label :ne_boundary_lat %>
-              <%= f.number_field :ne_boundary_lat, optional: true, value: @theme.ne_boundary_lat %>
+              <%= f.text_field :ne_boundary_lat, optional: true, value: @theme.ne_boundary_lat %>
             </div>
 
             <div class="input-group">
               <%= f.label :ne_boundary_long %>
-              <%= f.number_field :ne_boundary_long, optional: true, value: @theme.ne_boundary_long %>
+              <%= f.text_field :ne_boundary_long, optional: true, value: @theme.ne_boundary_long %>
             </div>
           </div>
         </div>
@@ -105,10 +105,10 @@
         <legend><%= t("map.center") %></legend>
         <div class="side-by-side">
           <div class="input-group">
-          <%= f.label :center_lat %><%= f.number_field :center_lat %>
+          <%= f.label :center_lat %><%= f.text_field :center_lat %>
           </div>
           <div class="input-group">
-          <%= f.label :center_long %><%= f.number_field :center_long %>
+          <%= f.label :center_long %><%= f.text_field :center_long %>
           </div>
         </div>
 


### PR DESCRIPTION
This ensures the input field for lat and long can accept any valid latitude or longitude value.

Before, the input would through a client-side validation error if the value was not a whole number. See discussion below for details.