### PR TITLE
Ensure the attached audio files display next to audio field

### DIFF
--- a/rails/app/views/dashboard/places/_form.html.erb
+++ b/rails/app/views/dashboard/places/_form.html.erb
@@ -6,10 +6,6 @@
 
   <%= f.label :name_audio %>
   <%= f.file_field :name_audio %>
-
-  <%= f.label :description %>
-  <%= f.text_area :description, rows: 3 %>
-
   <% if @place.name_audio.attached? %>
   <ul class="filename-list">
   <li class="file-item">
@@ -20,6 +16,9 @@
   </li>
   </ul>
   <% end %>
+
+  <%= f.label :description %>
+  <%= f.text_area :description, rows: 3 %>
 
   <%= f.label :photo %>
   <%= f.file_field :photo %>


### PR DESCRIPTION
Before, the attached audio file was displayed after description:
<img width="432" alt="image" src="https://user-images.githubusercontent.com/2660801/193680192-ca781db6-35b5-4dc9-be1f-f7d735a3ed22.png">

Now it's correctly displayed after the Placename Audio file.