### PR TITLE
Adjust word wrap for card header, aspect ratio for speaker images

### DIFF
--- a/rails/app/assets/stylesheets/cms/_cards.scss
+++ b/rails/app/assets/stylesheets/cms/_cards.scss
@@ -60,6 +60,7 @@
   &__img--circle {
     border-radius: 50%;
     width: 100%;
+    aspect-ratio: 1;
   }
 
   &__img {
@@ -109,5 +110,6 @@
   h3 {
     font-size: 1.25rem;
     margin-bottom: 0;
+    word-wrap: break-word;
   }
 }


### PR DESCRIPTION
Fixes word wrapping in one more place - card headers
![image](https://user-images.githubusercontent.com/31662219/193698714-8f5386fa-9254-4975-9085-c8b9202a629b.png)


Also, adjustment made to speaker images:

Before
![image](https://user-images.githubusercontent.com/31662219/193698653-8b1f031c-400e-4424-a9a7-f7ef75877dfd.png)

After
![image](https://user-images.githubusercontent.com/31662219/193698616-8df79e15-9f57-4eda-9ea9-21355a930b24.png)

Not ideal because it stretches / shrinks any images that are not square, but not sure how else to resolve this beside forcing the user to use square aspect ratio photos, or adding something like a gem to handle selecting a square area within an uploaded photo. Either way this feels like an improvement for now.