### PR TITLE
Fix: Stories Filtering

### DIFF
--- a/rails/app/pages/stories_page.rb
+++ b/rails/app/pages/stories_page.rb
@@ -12,8 +12,8 @@ class StoriesPage < Page
   def relation
     stories = @scoped_stories
 
-    stories = stories.joins(:places).where(places: {id: @meta[:place]}) if @meta[:place].present?
-    stories = stories.joins(:speakers).where(speakers: {id: @meta[:speaker]}) if @meta[:speaker].present?
+    stories = stories.joins(:places_stories).where(places_stories: {place_id: @meta[:place]}) if @meta[:place].present?
+    stories = stories.joins(:speaker_stories).where(speaker_stories: {speaker_id: @meta[:speaker]}) if @meta[:speaker].present?
     stories = stories.where(permission_level: @meta[:visibility]) if @meta[:visibility].present?
 
     stories.order(@meta[:sort_by] => @meta[:sort_dir])


### PR DESCRIPTION
Ensure that StoryPage correctly filters habtm relationships so ALL relations are shown even if only matched on one.

Essentially, rather than filtering from Story -> PlaceStory -> Place, we only go Story -> PlaceStory. Same for Speakers.

| Before | After |
| --- | --- |
| <img width="470" alt="image" src="https://user-images.githubusercontent.com/2660801/193894683-b92f718e-4f84-4345-94a0-f489f7ada098.png"> | <img width="503" alt="image" src="https://user-images.githubusercontent.com/2660801/193894617-2ac4c35a-be1a-4eb6-ae61-65b2b80b71ab.png"> |
