### PR TITLE
Feat: add map projection settings to Terrastories

### DIFF
--- a/documentation/CUSTOMIZATION.md
+++ b/documentation/CUSTOMIZATION.md
@@ -24,9 +24,13 @@ For offline "Field Kit" usage of Terrastories, you need to supply your own map t
 
 _**Note:** when using Mapbox.com maps with Terrastories, you are subject to Mapbox's [pricing schema](https://www.mapbox.com/pricing/) which has a free tier of up to 50,000 map loads per month. If you anticipate more monthly loads than that, you can get in touch with Mapbox's community team at community@mapbox.com to see what they can do to help._
 
-### Map extent, zoom, pitch, boundaries, and 3D Terrain
+### Map extent, zoom, pitch, boundaries, projection, and 3D Terrain
 
-It is possible to set a custom map extent, zoom level, pitch, and boundaries of the Terrastories map. Additionally, for online Terrastories maps, you can toggle on/off a realistic Mapbox 3D Terrain layer to view your maps in 3D. 3D Terrain adds another level of detail to the landscape, but requires more map and tile loading and therefore can impact the overall performance of Terrastories on your device.
+It is possible to set a custom map extent, zoom level, pitch, and boundaries of the Terrastories map.
+
+You can also set the map projection for your map to one of [the projections supported by Mapbox](https://docs.mapbox.com/help/glossary/projection/). The new Globe projection will be added when it is possible to do so.
+
+For online Terrastories maps, you can toggle on/off a realistic Mapbox 3D Terrain layer to view your maps in 3D. 3D Terrain adds another level of detail to the landscape, but requires more map and tile loading and therefore can impact the overall performance of Terrastories on your device.
 
 Setting these map properties can be done in the Terrastories `Theme` menu for a community when logged in as a user with admin permissions.
 ## Adding languages to Terrastories

--- a/documentation/DEVELOPMENT.md
+++ b/documentation/DEVELOPMENT.md
@@ -90,6 +90,6 @@ To start Terrastories with the offline profile, run
 docker compose --profile offline up
 ```
 
-In order to get the local tileserver map running, you will also need to generate an `MBtiles` dataset and place it in `tileserver/data/mbtiles/` with the filename `terrastories.mbtiles`, along with any fonts, sprites used in the map, and a `style.json` file that defines the appearance of the tiles. Please see the [customization guide](documentation/CUSTOMIZATION.md) for more information.
+In order to get the local tileserver map running, you will also need to generate an `MBtiles` dataset and place it in `tileserver/data/mbtiles/` with the filename `terrastories.mbtiles`, along with any fonts, sprites used in the map, and a `style.json` file that defines the appearance of the tiles. Please see the [customization guide](CUSTOMIZATION.md) for more information.
 
-For more information on running Terrastories in an offline environment, see [documentation/SETUP-OFFLINE.md](SETUP-OFFLINE.md)
+For more information on running Terrastories in an offline environment, see [SETUP-OFFLINE.md](SETUP-OFFLINE.md)

--- a/documentation/SETUP-OFFLINE.md
+++ b/documentation/SETUP-OFFLINE.md
@@ -29,7 +29,7 @@ Copy the contents of this file into a newly created file called `.env` (Do not c
 Terrastories in the "Field Kit" environment works by integrating map `tiles` and `styles`. Map tiles are square grids of spatial data consumed by the offline Tileserver, and can be in either raster (image) or vector format. Styles points the Terrastories tileserver to the tiles and in the case of vector data, gives style or symbology properties to the data (such as color, opacity, labels, visibility per zoom extent, and so on). Unlike the online environment (where Terrastories relies on Mapbox.com for all map content), each of these have to be made available to Terrastories in a file format.
 
 #### Default offline map tiles
-A default, open-license map for using offline with Terrastories is available at https://github.com/terrastories/default-offline/tiles. Download these files and place them in the `data` directory, and they should work when you load Terrastories in Field Kit mode.
+A default, open-license map for using offline with Terrastories is available at https://github.com/terrastories/default-offline-map. Download these files and place them in the `data` directory, and they should work when you load Terrastories in Field Kit mode.
 #### Working with custom MBTiles
 
 `MBTiles` can be generated from standard geospatial data (Shapefile, GeoJSON) in several ways. 
@@ -44,7 +44,7 @@ Once generated, place the `MBTiles` in the `tileserver/data/mbtiles/` directory,
 
 `Styles` (in style.json format) defines the visual appearance of a map: what data to draw, the order to draw it in, and how to style the data when drawing it. Mapbox provides a helpful [guide](https://docs.mapbox.com/mapbox-gl-js/style-spec/) with all of the possible style parameters, but it's generally useful to download an existing `style.json` file and modify it to suit your needs. One of the easiest ways to build a `style.json` file is by uploading and styling your data on [Mapbox Studio](http://mapbox.com/studio) and downloading the `style.json` file from there, in the following way:
 
-* Follow the map design process described [here](CUSTOMIZATION.md#setting-up-a-custom-map)
+* Follow the map design process described [here](CUSTOMIZATION.md#setting-up-a-custom-map).
 * In the Mapbox Studio environment, click "Share" and then download the Map style ZIP file.
 * Unzip the file, and extract the `style.json` and place it in `tileserver/data/styles`.
 * Next, you will need to make some changes. The `style.json` from Mapbox will be referring to an online URL for the map sources. You need to change this to refer to the local `MBTiles`. Change `sources` > `composite` > `url` to the following format: `"url": "MBTiles://MBTiles/name.MBTiles"`. (Here, `name` is just an example; it can be called whatever you want, so long as the filename is the same.)
@@ -76,7 +76,7 @@ You can define multiple `mbtiles` sources (vector as well as raster), and place 
 
 ## Setup and running the server
 
-Once you have prepped the environment and offline map content, you may proceed to [the standard guides per operating system](/README.md#setup) to follow the same process for building and starting Terrastories, with one exception: changing the Docker profile from `dev` to `offline`. So, you would run:
+Once you have prepped the environment and offline map content, you may proceed to [the standard guides per operating system](/README.md#install-terrastories) to follow the same process for building and starting Terrastories, with one exception: changing the Docker profile from `dev` to `offline`. So, you would run:
 
 ```bash
 docker compose --profile offline build

--- a/rails/app/controllers/dashboard/themes_controller.rb
+++ b/rails/app/controllers/dashboard/themes_controller.rb
@@ -49,6 +49,7 @@ module Dashboard
         :zoom,
         :pitch,
         :bearing,
+        :map_projection,
         sponsor_logos: []
       )
     end

--- a/rails/app/dashboards/theme_dashboard.rb
+++ b/rails/app/dashboards/theme_dashboard.rb
@@ -24,7 +24,8 @@ class ThemeDashboard < Administrate::BaseDashboard
     ne_boundary_long: Field::Number,
     zoom: Field::Number,
     pitch: Field::Number,
-    bearing: Field::Number
+    bearing: Field::Number,
+    map_projection: EnumField
   }.freeze
 
   # COLLECTION_ATTRIBUTES
@@ -55,6 +56,7 @@ class ThemeDashboard < Administrate::BaseDashboard
   zoom
   pitch
   bearing
+  map_projection
   ].freeze
 
   # FORM_ATTRIBUTES
@@ -75,6 +77,7 @@ class ThemeDashboard < Administrate::BaseDashboard
   zoom
   pitch
   bearing
+  map_projection
   ].freeze
 
   # COLLECTION_FILTERS
@@ -97,6 +100,6 @@ class ThemeDashboard < Administrate::BaseDashboard
   end
 
   def permitted_attributes
-    super + [:sponsor_logos => []]
+    super + [:sponsor_logos => [], map_projection: [:mercator, :albers, :equalEarth, :equirectangular, :lambertConformalConic, :naturalEarth, :winkelTripel]]
   end
 end

--- a/rails/app/javascript/components/App.jsx
+++ b/rails/app/javascript/components/App.jsx
@@ -30,6 +30,7 @@ class App extends Component {
     mapbox_access_token: PropTypes.string,
     mapbox_style: PropTypes.string,
     mapbox_3d: PropTypes.bool,
+    map_projection: PropTypes.string,
     logo_path: PropTypes.string,
     user: PropTypes.object,
     center_lat: PropTypes.string,
@@ -350,6 +351,7 @@ class App extends Component {
           useLocalMapServer={this.props.use_local_map_server}
           mapboxStyle={this.props.mapbox_style}
           mapbox3d={this.props.mapbox_3d}
+          mapProjection={this.props.map_projection}
           clearFilteredStories={this.resetStoriesAndMap}
           onMapPointClick={this.handleMapPointClick}
           activePoint={this.state.activePoint}

--- a/rails/app/javascript/components/Map.jsx
+++ b/rails/app/javascript/components/Map.jsx
@@ -24,6 +24,7 @@ export default class Map extends Component {
     mapboxStyle: PropTypes.string,
     mapboxAccessToken: PropTypes.string,
     mapbox3d: PropTypes.bool,
+    mapProjection: PropTypes.string,
     useLocalMapServer: PropTypes.bool,
     markerImgUrl: PropTypes.string,
     markerClusterImgUrl: PropTypes.string,
@@ -37,7 +38,8 @@ export default class Map extends Component {
         zoom: this.props.zoom,
         maxBounds: this.checkBounds(), // check for bounding box presence
         pitch: this.props.pitch,
-        bearing: this.props.bearing
+        bearing: this.props.bearing,
+        projection: this.props.mapProjection
     });
 
     this.map.on("load", () => {
@@ -109,8 +111,8 @@ export default class Map extends Component {
           'maxzoom': 14
         });
     
-        // add the DEM source as a terrain layer with exaggerated height
-        this.map.setTerrain({ 'source': 'mapbox-dem', 'exaggeration': 1.5 });
+        // add the DEM source as a terrain layer
+        this.map.setTerrain({ 'source': 'mapbox-dem' });
           
         // add a sky layer that will show when the map is highly pitched
         this.map.addLayer({

--- a/rails/app/models/concerns/map_configurable.rb
+++ b/rails/app/models/concerns/map_configurable.rb
@@ -6,6 +6,7 @@ module MapConfigurable
     self.zoom ||= 2
     self.pitch ||= 0
     self.bearing ||= 0
+    self.map_projection ||= 0
   end
 
   def center

--- a/rails/app/models/theme.rb
+++ b/rails/app/models/theme.rb
@@ -66,6 +66,8 @@ class Theme < ApplicationRecord
     errors.add(:sw_boundary_long, :invalid_longitude) unless (-180..180).include?(sw_boundary_long)
     errors.add(:ne_boundary_long, :invalid_longitude) unless (-180..180).include?(ne_boundary_long)
   end
+
+  enum map_projection: [:mercator, :albers, :equalEarth, :equirectangular, :lambertConformalConic, :naturalEarth, :winkelTripel] 
 end
 
 # == Schema Information
@@ -80,6 +82,7 @@ end
 #  mapbox_access_token :string
 #  mapbox_style_url    :string
 #  mapbox_3d           :boolean          default(FALSE), not null
+#  map_projection      :decimal
 #  ne_boundary_lat     :decimal(10, 6)
 #  ne_boundary_long    :decimal(10, 6)
 #  pitch               :decimal(10, 6)

--- a/rails/app/views/dashboard/themes/edit.html.erb
+++ b/rails/app/views/dashboard/themes/edit.html.erb
@@ -125,6 +125,9 @@
       <%= f.label :bearing %>
       <span id="bearingValue"><%= @theme.bearing %></span>
       <%= f.range_field :bearing, min: -180, max: 180 %>
+
+      <%= f.label :map_projection %>
+      <%= f.select :map_projection, [:mercator, :albers, :equalEarth, :equirectangular, :lambertConformalConic, :naturalEarth, :winkelTripel] %>
     </div>
 
     <div class="two-columns-right">

--- a/rails/app/views/dashboard/themes/edit.html.erb
+++ b/rails/app/views/dashboard/themes/edit.html.erb
@@ -173,6 +173,7 @@ const themeMap = new mapboxgl.Map({
   pitch: <%= @theme.pitch  || 0 %>, // starting pitch
   bearing: <%= @theme.bearing  || 0 %>, // starting bearing
   style: "<%= @theme.mapbox_style %>", // style URL or style object
+  projection: "<%= @theme.map_projection %>",
   hash: false,
   cooperativeGestures: true
 });

--- a/rails/app/views/dashboard/themes/edit.html.erb
+++ b/rails/app/views/dashboard/themes/edit.html.erb
@@ -127,7 +127,7 @@
       <%= f.range_field :bearing, min: -180, max: 180 %>
 
       <%= f.label :map_projection %>
-      <%= f.select :map_projection, [:mercator, :albers, :equalEarth, :equirectangular, :lambertConformalConic, :naturalEarth, :winkelTripel] %>
+      <%= f.select :map_projection, t("map.projection").map { |k, v| [v, k] } %>
     </div>
 
     <div class="two-columns-right">

--- a/rails/app/views/home/_home.json.jbuilder
+++ b/rails/app/views/home/_home.json.jbuilder
@@ -27,6 +27,7 @@ json.user current_user
 json.mapbox_access_token @theme.mapbox_token
 json.mapbox_style @theme.mapbox_style
 json.mapbox_3d @theme.mapbox_3d
+json.map_projection @theme.map_projection
 json.use_local_map_server @theme.offline_mode?
 json.center_lat @theme.center_lat
 json.center_long @theme.center_long

--- a/rails/config/locales/en/administrate.en.yml
+++ b/rails/config/locales/en/administrate.en.yml
@@ -34,6 +34,7 @@ en:
         mapbox_style_url: Mapbox style URL (for online maps)
         mapbox_access_token: Mapbox access token associated with the style
         mapbox_3d: Activate 3D Terrain view for online map
+        map_projection: Set projection for map
         center_lat: Map center, latitude
         center_long: Map center, longitude
         sw_boundary_lat: SW bounding box, latitude (optional)

--- a/rails/config/locales/en/dashboard.en.yml
+++ b/rails/config/locales/en/dashboard.en.yml
@@ -12,13 +12,14 @@ en:
     online: Online Map Configuration
     settings: Map Settings
     settings_description: Customize your community's map settings.
-    mercator: Mercator
-    albers: Albers
-    equalEarth: Equal Earth
-    equirectangular: Equirectangular
-    lambertConformalConic: Lambert Comformal Conic
-    naturalEarth: Natural Earth
-    winkelTripel: Winkel Tripel
+    projection:
+      mercator: Mercator
+      albers: Albers
+      equalEarth: Equal Earth
+      equirectangular: Equirectangular
+      lambertConformalConic: Lambert Comformal Conic
+      naturalEarth: Natural Earth
+      winkelTripel: Winkel Tripel
   dashboard:
     back_to_app: Back to App
     community_settings: Community Settings

--- a/rails/config/locales/en/dashboard.en.yml
+++ b/rails/config/locales/en/dashboard.en.yml
@@ -12,6 +12,13 @@ en:
     online: Online Map Configuration
     settings: Map Settings
     settings_description: Customize your community's map settings.
+    mercator: Mercator
+    albers: Albers
+    equalEarth: Equal Earth
+    equirectangular: Equirectangular
+    lambertConformalConic: Lambert Comformal Conic
+    naturalEarth: Natural Earth
+    winkelTripel: Winkel Tripel
   dashboard:
     back_to_app: Back to App
     community_settings: Community Settings

--- a/rails/config/locales/en/models.en.yml
+++ b/rails/config/locales/en/models.en.yml
@@ -96,7 +96,8 @@ en:
         ne_boundary_long: Max Longitude
         zoom: Zoom level
         pitch: Pitch degree
-        bearing: Bearing degress
+        bearing: Bearing degrees
+        map_projection: Set projection for map
       user:
         email: Email
         role: Role

--- a/rails/config/locales/es/administrate.es.yml
+++ b/rails/config/locales/es/administrate.es.yml
@@ -30,6 +30,7 @@ es:
         mapbox_style_url: URL de estilo Mapbox (para mapas en línea)
         mapbox_access_token: Token de acceso a Mapbox asociado al estilo
         mapbox_3d: Activar la vista de terreno 3D para el mapa en línea
+        map_projection: Establecer proyección para el mapa
         center_lat: Centro del mapa, latitud
         center_long: Centro del mapa, longitud
         sw_boundary_lat: SW cuadro delimitador, latitud (opcional)

--- a/rails/config/locales/es/dashboard.es.yml
+++ b/rails/config/locales/es/dashboard.es.yml
@@ -12,7 +12,6 @@ es:
     online: Online Map Configuration
     settings: Configuración del Mapa
     settings_description: Customize your community's map settings.
-    map_projection: Establecer proyección para el mapa
     projection:
       mercator: Mercator
       albers: Albers

--- a/rails/config/locales/es/dashboard.es.yml
+++ b/rails/config/locales/es/dashboard.es.yml
@@ -12,6 +12,15 @@ es:
     online: Online Map Configuration
     settings: Configuración del Mapa
     settings_description: Customize your community's map settings.
+    map_projection: Establecer proyección para el mapa
+    projection:
+      mercator: Mercator
+      albers: Albers
+      equalEarth: Equal Earth
+      equirectangular: Equirectangular
+      lambertConformalConic: Lambert Comformal Conic
+      naturalEarth: Natural Earth
+      winkelTripel: Winkel Tripel
   dashboard:
     back_to_app: Regresar a la aplicación
     community_settings: Community Settings

--- a/rails/config/locales/es/models.es.yml
+++ b/rails/config/locales/es/models.es.yml
@@ -97,6 +97,7 @@ es:
         zoom: Nivel de zoom
         pitch: Grado de tono
         bearing: Grado de orientación
+        map_projection: Establecer proyección para el mapa
       user:
         email: Correo electrónico
         role: Rol

--- a/rails/config/locales/ja/administrate.ja.yml
+++ b/rails/config/locales/ja/administrate.ja.yml
@@ -15,6 +15,26 @@ ja:
           editor_only: "編集者"
           admin_only: "管理者"
       theme:
+        background_img: Background image (for welcome screen)
+        sponsor_logos: Sponsor logos (for welcome screen)
+        mapbox_style_url: Mapbox style URL (for online maps)
+        mapbox_access_token: Mapbox access token associated with the style
+        mapbox_3d: Activate 3D Terrain view for online map
+        map_projection: Set projection for map
+        center_lat: Map center, latitude
+        center_long: Map center, longitude
+        sw_boundary_lat: SW bounding box, latitude (optional)
+        sw_boundary_long: SW bounding box, longitude (optional)
+        ne_boundary_lat: NE bounding box, latitude (optional)
+        ne_boundary_long: NE bounding box, longitude (optional)
+        background_img: Background Image
+        sponsor_logos: Sponsor Logos
+        mapbox_style_url: Mapbox Style URL
+        mapbox_access_token: Mapbox access token associated with the style
+        mapbox_3d: Activate 3D Terrain view for online map
+        zoom: Zoom level
+        pitch: Pitch degree
+        bearing: Bearing degree
         display_resource: "のテーマ Terrastories: %{community_name}"
   administrate:
     actions:

--- a/rails/config/locales/ja/dashboard.ja.yml
+++ b/rails/config/locales/ja/dashboard.ja.yml
@@ -12,6 +12,15 @@ ja:
     online: Online Map Configuration
     settings: Map Settings
     settings_description: Customize your community's map settings.
+    map_projection: Set projection for map
+    projection:
+      mercator: Mercator
+      albers: Albers
+      equalEarth: Equal Earth
+      equirectangular: Equirectangular
+      lambertConformalConic: Lambert Comformal Conic
+      naturalEarth: Natural Earth
+      winkelTripel: Winkel Tripel
   dashboard:
     back_to_app: Back to App
     community_settings: Community Settings

--- a/rails/config/locales/ja/dashboard.ja.yml
+++ b/rails/config/locales/ja/dashboard.ja.yml
@@ -12,7 +12,6 @@ ja:
     online: Online Map Configuration
     settings: Map Settings
     settings_description: Customize your community's map settings.
-    map_projection: Set projection for map
     projection:
       mercator: Mercator
       albers: Albers

--- a/rails/config/locales/ja/models.ja.yml
+++ b/rails/config/locales/ja/models.ja.yml
@@ -96,7 +96,8 @@ ja:
         ne_boundary_long: Max Longitude
         zoom: Zoom level
         pitch: Pitch degree
-        bearing: Bearing degress
+        bearing: Bearing degrees
+        map_projection: Set projection for map
       user:
         email: Email
         role: ロール

--- a/rails/config/locales/mat/administrate.mat.yml
+++ b/rails/config/locales/mat/administrate.mat.yml
@@ -16,6 +16,26 @@ mat:
           editor_only: "Editor"
           admin_only: "Admin"
       theme:
+        background_img: Background image (for welcome screen)
+        sponsor_logos: Sponsor logos (for welcome screen)
+        mapbox_style_url: Mapbox style URL (for online maps)
+        mapbox_access_token: Mapbox access token associated with the style
+        mapbox_3d: Activate 3D Terrain view for online map
+        map_projection: Set projection for map
+        center_lat: Map center, latitude
+        center_long: Map center, longitude
+        sw_boundary_lat: SW bounding box, latitude (optional)
+        sw_boundary_long: SW bounding box, longitude (optional)
+        ne_boundary_lat: NE bounding box, latitude (optional)
+        ne_boundary_long: NE bounding box, longitude (optional)
+        background_img: Background Image
+        sponsor_logos: Sponsor Logos
+        mapbox_style_url: Mapbox Style URL
+        mapbox_access_token: Mapbox access token associated with the style
+        mapbox_3d: Activate 3D Terrain view for online map
+        zoom: Zoom level
+        pitch: Pitch degree
+        bearing: Bearing degree
         display_resource: "Thema voor Terrastories: %{community_name}"
   administrate:
     actions:

--- a/rails/config/locales/mat/dashboard.mat.yml
+++ b/rails/config/locales/mat/dashboard.mat.yml
@@ -12,6 +12,15 @@ mat:
     online: Online Map Configuration
     settings: Map Settings
     settings_description: Customize your community's map settings.
+    map_projection: Set projection for map
+    projection:
+      mercator: Mercator
+      albers: Albers
+      equalEarth: Equal Earth
+      equirectangular: Equirectangular
+      lambertConformalConic: Lambert Comformal Conic
+      naturalEarth: Natural Earth
+      winkelTripel: Winkel Tripel
   dashboard:
     back_to_app: Back to App
     community_settings: Community Settings

--- a/rails/config/locales/mat/dashboard.mat.yml
+++ b/rails/config/locales/mat/dashboard.mat.yml
@@ -12,7 +12,6 @@ mat:
     online: Online Map Configuration
     settings: Map Settings
     settings_description: Customize your community's map settings.
-    map_projection: Set projection for map
     projection:
       mercator: Mercator
       albers: Albers

--- a/rails/config/locales/mat/models.mat.yml
+++ b/rails/config/locales/mat/models.mat.yml
@@ -96,7 +96,8 @@ mat:
         ne_boundary_long: Max Longitude
         zoom: Zoom level
         pitch: Pitch degree
-        bearing: Bearing degress
+        bearing: Bearing degrees
+        map_projection: Set projection for map
       user:
         email: Email
         role: Rol

--- a/rails/config/locales/nl/administrate.nl.yml
+++ b/rails/config/locales/nl/administrate.nl.yml
@@ -16,6 +16,26 @@ nl:
           editor_only: "Editor"
           admin_only: "Admin"
       theme:
+        background_img: Background image (for welcome screen)
+        sponsor_logos: Sponsor logos (for welcome screen)
+        mapbox_style_url: Mapbox style URL (for online maps)
+        mapbox_access_token: Mapbox access token associated with the style
+        mapbox_3d: Activate 3D Terrain view for online map
+        map_projection: Projectie instellen voor kaart
+        center_lat: Map center, latitude
+        center_long: Map center, longitude
+        sw_boundary_lat: SW bounding box, latitude (optional)
+        sw_boundary_long: SW bounding box, longitude (optional)
+        ne_boundary_lat: NE bounding box, latitude (optional)
+        ne_boundary_long: NE bounding box, longitude (optional)
+        background_img: Background Image
+        sponsor_logos: Sponsor Logos
+        mapbox_style_url: Mapbox Style URL
+        mapbox_access_token: Mapbox access token associated with the style
+        mapbox_3d: Activate 3D Terrain view for online map
+        zoom: Zoom level
+        pitch: Pitch degree
+        bearing: Bearing degree
         display_resource: "Thema voor Terrastories: %{community_name}"
   administrate:
     actions:

--- a/rails/config/locales/nl/dashboard.nl.yml
+++ b/rails/config/locales/nl/dashboard.nl.yml
@@ -12,6 +12,15 @@ nl:
     online: Online Map Configuration
     settings: Map Settings
     settings_description: Customize your community's map settings.
+    map_projection: Projectie instellen voor kaart
+    projection:
+      mercator: Mercator
+      albers: Albers
+      equalEarth: Equal Earth
+      equirectangular: Equirectangular
+      lambertConformalConic: Lambert Comformal Conic
+      naturalEarth: Natural Earth
+      winkelTripel: Winkel Tripel
   dashboard:
     back_to_app: Back to App
     community_settings: Community Settings

--- a/rails/config/locales/nl/dashboard.nl.yml
+++ b/rails/config/locales/nl/dashboard.nl.yml
@@ -12,7 +12,6 @@ nl:
     online: Online Map Configuration
     settings: Map Settings
     settings_description: Customize your community's map settings.
-    map_projection: Projectie instellen voor kaart
     projection:
       mercator: Mercator
       albers: Albers

--- a/rails/config/locales/nl/models.nl.yml
+++ b/rails/config/locales/nl/models.nl.yml
@@ -96,7 +96,8 @@ nl:
         ne_boundary_long: Max Longitude
         zoom: Zoom level
         pitch: Pitch degree
-        bearing: Bearing degress
+        bearing: Bearing degrees
+        map_projection: Projectie instellen voor kaart
       user:
         email: Email
         role: Rol

--- a/rails/config/locales/pt/administrate.pt.yml
+++ b/rails/config/locales/pt/administrate.pt.yml
@@ -30,6 +30,7 @@ pt:
         mapbox_style_url: URL do estilo Mapbox (para mapas online)
         mapbox_access_token: Token de acesso do Mapbox associado ao estilo
         mapbox_3d: Ative a visualização 3D do terreno para o mapa online
+        map_projection: Definir projeção para o mapa
         center_lat: Centro do mapa, latitude
         center_long: Centro do mapa, longitude
         sw_boundary_lat: SW caixa delimitadora, latitude (opcional)

--- a/rails/config/locales/pt/dashboard.pt.yml
+++ b/rails/config/locales/pt/dashboard.pt.yml
@@ -12,6 +12,15 @@ pt:
     online: Online Map Configuration
     settings: Map Settings
     settings_description: Customize your community's map settings.
+    map_projection: Definir projeção para o mapa
+    projection:
+      mercator: Mercator
+      albers: Albers
+      equalEarth: Equal Earth
+      equirectangular: Equirectangular
+      lambertConformalConic: Lambert Comformal Conic
+      naturalEarth: Natural Earth
+      winkelTripel: Winkel Tripel
   dashboard:
     back_to_app: Back to App
     community_settings: Community Settings

--- a/rails/db/migrate/20220812190620_add_map_projection.rb
+++ b/rails/db/migrate/20220812190620_add_map_projection.rb
@@ -1,0 +1,5 @@
+class AddMapProjection < ActiveRecord::Migration[6.0]
+    def change
+      add_column :themes, :map_projection, :integer, default: 0
+    end
+  end

--- a/rails/db/schema.rb
+++ b/rails/db/schema.rb
@@ -136,7 +136,7 @@ ActiveRecord::Schema.define(version: 2022_09_28_202901) do
     t.decimal "pitch", precision: 10, scale: 6
     t.decimal "bearing", precision: 10, scale: 6
     t.boolean "mapbox_3d", default: false
-    t.integer "map_projection"
+    t.integer "map_projection", default: 0
   end
 
   create_table "users", force: :cascade do |t|

--- a/rails/db/schema.rb
+++ b/rails/db/schema.rb
@@ -136,6 +136,7 @@ ActiveRecord::Schema.define(version: 2022_09_28_202901) do
     t.decimal "pitch", precision: 10, scale: 6
     t.decimal "bearing", precision: 10, scale: 6
     t.boolean "mapbox_3d", default: false
+    t.integer "map_projection"
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
Closes https://github.com/Terrastories/terrastories/issues/790.

This PR adds a field `map_projection` to the `themes` model, sets it to `mercator` by default, and permits an admin user to change the projection in the Themes menu to one of six possible projections that are supported by Mapbox GL JS 2.7. The map on the front end will then use that projection set by the admin user.

![image](https://user-images.githubusercontent.com/31662219/193898463-9e5bc797-fa49-4b07-bce7-734567c11247.png)
Natural Earth:
![image](https://user-images.githubusercontent.com/31662219/184505200-8f4a1277-6558-4f87-9b9e-b86e19cb5c97.png)

Albers:
![image](https://user-images.githubusercontent.com/31662219/184505233-218999cf-6b37-4653-aa0f-0e04c9bbbd80.png)

Lambert Conformal Conic:
![image](https://user-images.githubusercontent.com/31662219/184505249-191b3e40-dbcd-4e0f-acfa-a54720491abd.png)

Works with default offline vector tiles and TileServer-GL while entirely offline:
![image](https://user-images.githubusercontent.com/31662219/184505605-9461cc3e-7385-42e5-aebe-8bc04692ecb0.png)

Once `mapbox-gl-rails` updates to 2.9, we can file a small PR to add the `globe` projection as well, but will likely have to account for this not working with TileServer-GL when offline.

Lastly, a few small housekeeping fixes:
* Move the `zoom`, `pitch`, and `bearing` fields above the bounding box fields in the Theme menu, since these are more useful to the user than the bounding box.
* Fixing broken links in documentation
* Reset 3d terrain exaggeration to 1 (default)