### PR TITLE
Feat: allow signin with username (in addition to email)

### DIFF
--- a/rails/app/assets/stylesheets/cms/_flash.scss
+++ b/rails/app/assets/stylesheets/cms/_flash.scss
@@ -3,7 +3,6 @@ div.flash-messages {
   width: 100%;
   display: grid;
   place-items: center;
-  z-index: 1000;
 }
 
 span.flash {
@@ -14,6 +13,7 @@ span.flash {
   margin: 1rem;
   border: 1px solid $dark-green;
   opacity: 1;
+  z-index: 1000;
 
   max-width: 30vw;
 

--- a/rails/app/controllers/dashboard/users_controller.rb
+++ b/rails/app/controllers/dashboard/users_controller.rb
@@ -76,6 +76,8 @@ module Dashboard
 
     def user_params
       params.require(:user).permit(
+        :name,
+        :username,
         :email,
         :password,
         :role,

--- a/rails/app/controllers/dashboard/users_controller.rb
+++ b/rails/app/controllers/dashboard/users_controller.rb
@@ -41,6 +41,11 @@ module Dashboard
       @user = authorize community.users.find(params[:id])
     end
 
+    def profile
+      @user = current_user
+      render :edit
+    end
+
     def update
       @user = authorize community.users.find(params[:id])
 

--- a/rails/app/controllers/registrations_controller.rb
+++ b/rails/app/controllers/registrations_controller.rb
@@ -1,12 +1,12 @@
 class RegistrationsController < Devise::RegistrationsController
 
     private
-  
+
     def sign_up_params
-      params.require(:user).permit(:email, :role, :password, :password_confirmation)
+      params.require(:user).permit(:username, :name, :email, :role, :password, :password_confirmation)
     end
-  
+
     def account_update_params
-      params.require(:user).permit(:email, :role, :password, :password_confirmation, :current_password)
+      params.require(:user).permit(:username, :name, :email, :role, :password, :password_confirmation, :current_password)
     end
   end

--- a/rails/app/models/user.rb
+++ b/rails/app/models/user.rb
@@ -26,6 +26,10 @@ class User < ApplicationRecord
     self.role ||= :viewer
   end
 
+  def display_name
+    name.presence || username
+  end
+
   # Override Devise authentication to allow lookup via username or email
   def self.find_first_by_auth_conditions(tainted_conditions)
     if (login = tainted_conditions.delete(:login))

--- a/rails/app/models/user.rb
+++ b/rails/app/models/user.rb
@@ -33,12 +33,14 @@ end
 #  encrypted_password     :string           default(""), not null
 #  last_sign_in_at        :datetime
 #  last_sign_in_ip        :string
+#  name                   :string
 #  remember_created_at    :datetime
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string
 #  role                   :integer
 #  sign_in_count          :integer          default(0), not null
 #  super_admin            :boolean          default(FALSE), not null
+#  username               :string           default(""), not null
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #  community_id           :integer
@@ -47,4 +49,5 @@ end
 #
 #  index_users_on_email                 (email) UNIQUE
 #  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#  index_users_on_username              (username) UNIQUE
 #

--- a/rails/app/views/dashboard/places/_places.html.erb
+++ b/rails/app/views/dashboard/places/_places.html.erb
@@ -1,7 +1,11 @@
 <% @places.each do |place| %>
   <%= link_to place_path(place), class: "card card--stacked" do %>
     <% if place.photo.attached? %>
-      <%= image_tag url_for(place.photo), class: "card__img", alt: place.name, title: place.name %>
+      <% if place.photo.variable? %>
+        <%= image_tag place.photo.variant(resize_to_limit: [nil, 300]), class: "card__img", alt: place.name, title: place.name %>
+      <% else %>
+        <%= image_tag place.photo, class: "card__img", alt: place.name, title: place.name %>
+      <% end %>
     <% else %>
       <%= image_tag asset_path("home-icon.svg"), class: "card__img", alt: place.name, title: place.name, height: 150 %>
     <% end %>

--- a/rails/app/views/dashboard/places/edit.html.erb
+++ b/rails/app/views/dashboard/places/edit.html.erb
@@ -6,7 +6,11 @@
   <div class="avatar-card">
     <span class="media-with-hover-controls rounded" data-replace-on-delete="<%= asset_path("home-icon.svg") %>">
       <% if @place.photo.attached? %>
-        <%= image_tag @place.photo, alt: @place.name, title: @place.name %>
+        <% if @place.photo.variable? %>
+          <%= image_tag @place.photo.variant(resize_to_fill: [300, 300]), alt: @place.name, title: @place.name %>
+        <% else %>
+          <%= image_tag @place.photo, alt: @place.name, title: @place.name %>
+        <% end %>
         <%= link_to place_photo_path(@place), class: "overlay delete-link", method: :delete, data: {confirm: t("dashboard.actions.confirm")}, remote: true do %>
           <span><%= t("dashboard.actions.destroy") %></span>
         <% end %>

--- a/rails/app/views/dashboard/places/show.html.erb
+++ b/rails/app/views/dashboard/places/show.html.erb
@@ -6,7 +6,11 @@
 <div class="columns">
   <div class="avatar-card">
     <% if @place.photo.attached? %>
-      <%= image_tag @place.photo, class: "img--rounded img--mega", alt: @place.name, title: @place.name %>
+      <% if @place.photo.variable? %>
+        <%= image_tag @place.photo.variant(resize_to_fill: [300, 300]), class: "img--rounded img--mega", alt: @place.name, title: @place.name %>
+      <% else %>
+        <%= image_tag @place.photo, class: "img--rounded img--mega", alt: @place.name, title: @place.name %>
+      <% end %>
     <% else %>
       <%= image_tag asset_path("home-icon.svg"), class: "img--rounded img--mega", alt: @place.name, title: @place.name %>
     <% end %>

--- a/rails/app/views/dashboard/speakers/_speakers.html.erb
+++ b/rails/app/views/dashboard/speakers/_speakers.html.erb
@@ -1,9 +1,13 @@
 <% @speakers.each do |speaker| %>
   <%= link_to speaker, class: "card card--narrow card--stacked card--center" do %>
     <% if speaker.photo.attached? %>
-      <%= image_tag url_for(speaker.photo), class: "card__img--circle" %>
+      <% if speaker.photo.variable? %>
+        <%= image_tag speaker.photo.variant(resize_to_fill: [300, 300]), class: "card__img--circle", alt: speaker.name, title: speaker.name %>
+      <% else %>
+        <%= image_tag speaker.photo, class: "card__img--circle", alt: speaker.name, title: speaker.name %>
+      <% end %>
     <% else %>
-      <%= image_tag asset_path("speaker.png"), class: "card__img--circle" %>
+      <%= image_tag asset_path("speaker.png"), class: "card__img--circle", alt: speaker.name, title: speaker.name %>
     <% end %>
     <div><%= speaker.name %></div>
     <% if speaker.speaker_community.present? %>

--- a/rails/app/views/dashboard/speakers/edit.html.erb
+++ b/rails/app/views/dashboard/speakers/edit.html.erb
@@ -6,7 +6,11 @@
 <div class="avatar-card">
   <span class="media-with-hover-controls rounded" data-replace-on-delete="<%= asset_path("speaker.png") %>">
     <% if @speaker.photo.attached? %>
-      <%= image_tag @speaker.photo, alt: @speaker.name, title: @speaker.name %>
+      <% if @speaker.photo.variable? %>
+        <%= image_tag @speaker.photo.variant(resize_to_fill: [300, 300]), alt: @speaker.name, title: @speaker.name %>
+      <% else %>
+        <%= image_tag @speaker.photo %>
+      <% end %>
       <%= link_to speaker_photo_path(@speaker), class: "overlay delete-link", method: :delete, data: {confirm: t("dashboard.actions.confirm")}, remote: true do %>
         <span><%= t("dashboard.actions.destroy") %></span>
       <% end %>

--- a/rails/app/views/dashboard/speakers/show.html.erb
+++ b/rails/app/views/dashboard/speakers/show.html.erb
@@ -6,7 +6,11 @@
 <div class="columns">
   <div class="avatar-card">
     <% if @speaker.photo.attached? %>
-      <%= image_tag @speaker.photo, class: "img--rounded img--mega", alt: @speaker.name, title: @speaker.name %>
+      <% if @speaker.photo.variable? %>
+        <%= image_tag @speaker.photo.variant(resize_to_fill: [300, 300]), class: "img--rounded img--mega", alt: @speaker.name, title: @speaker.name %>
+      <% else %>
+        <%= image_tag @speaker.photo, class: "img--rounded img--mega", alt: @speaker.name, title: @speaker.name %>
+      <% end %>
     <% else %>
       <%= image_tag asset_path("speaker.png"), class: "img--rounded img--mega", alt: @speaker.name, title: @speaker.name %>
     <% end %>

--- a/rails/app/views/dashboard/stories/_stories.html.erb
+++ b/rails/app/views/dashboard/stories/_stories.html.erb
@@ -30,7 +30,11 @@
         <% story.speakers.each do |speaker| %>
           <span class="tooltip">
             <% if speaker.photo.attached? %>
-              <%= image_tag speaker.photo, class: "img--rounded img--mini", alt: speaker.name, title: speaker.name %>
+              <% if speaker.photo.variable? %>
+                <%= image_tag speaker.photo.variant(resize_to_fill: [100, 100]), class: "img--rounded img--mini" %>
+              <% else %>
+                <%= image_tag speaker.photo, class: "img--rounded img--mini", alt: speaker.name, title: speaker.name %>
+              <% end %>
             <% else %>
               <%= image_tag asset_path("speaker.png"), class: "img--rounded img--mini", alt: speaker.name, title: speaker.name %>
             <% end %>

--- a/rails/app/views/dashboard/stories/show.html.erb
+++ b/rails/app/views/dashboard/stories/show.html.erb
@@ -50,7 +50,11 @@
       <% if @story.interviewer %>
         <span class="card card--mini card--center card--noborder card--nogap">
           <% if @story.interviewer.photo.attached? %>
-            <%= image_tag @story.interviewer.photo, class: "img--rounded img--large", alt: @story.interviewer.name, title: @story.interviewer.name %>
+            <% if @story.interviewer.photo.variable? %>
+              <%= image_tag  @story.interviewer.photo.variant(resize_to_fill: [300, 300]), class: "img--rounded img--large", alt: @story.interviewer.name, title: @story.interviewer.name %>
+            <% else %>
+              <%= image_tag  @story.interviewer.photo, class: "img--rounded img--large", alt: @story.interviewer.name, title: @story.interviewer.name %>
+            <% end %>
           <% else %>
             <%= image_tag asset_path("speaker.png"), class: "img--rounded img--large", alt: @story.interviewer.name, title: @story.interviewer.name %>
           <% end %>
@@ -62,7 +66,11 @@
       <% policy_scope(@story.speakers).each do |speaker| %>
         <span class="card card--mini card--center card--noborder card--nogap">
           <% if speaker.photo.attached? %>
-            <%= image_tag speaker.photo, class: "img--rounded img--large", alt: speaker.name, title: speaker.name %>
+            <% if speaker.photo.variable? %>
+              <%= image_tag speaker.photo.variant(resize_to_fill: [300, 300]), class: "img--rounded img--large", alt: speaker.name, title: speaker.name %>
+            <% else %>
+              <%= image_tag speaker.photo, class: "img--rounded img--large", alt: speaker.name, title: speaker.name %>
+            <% end %>
           <% else %>
             <%= image_tag asset_path("speaker.png"), class: "img--rounded img--large", alt: speaker.name, title: speaker.name %>
           <% end %>

--- a/rails/app/views/dashboard/users/_form.html.erb
+++ b/rails/app/views/dashboard/users/_form.html.erb
@@ -1,15 +1,25 @@
 <%= form_with model: @user, multipart: true, class: "form", data: {remote: false}, id: "userForm", locale: true do |f| %>
   <%= render partial: "shared/form_errors", locals: { resource: @user } %>
 
+  <%= f.label :name %>
+  <%= f.text_field :name %>
+
+  <%= f.label :username, class: "required" %>
+  <%= f.text_field :username, required: true %>
+
   <%= f.label :email %>
   <%= f.email_field :email %>
+
   <%= f.label :password %>
   <%= f.password_field :password %>
+
   <% unless !((current_user.super_admin || current_user.admin?) && @user.id != current_user.id) %>
     <%= f.label :role %>
     <%= f.select :role, User.roles.keys.excluding('super_admin').map { |k| [User.human_attribute_name("role.#{k}"), k] } %>
   <% end %>
+
   <%= f.label :photo %>
   <%= f.file_field :photo %>
+
   <%= f.submit %>
 <% end %>

--- a/rails/app/views/dashboard/users/_users.html.erb
+++ b/rails/app/views/dashboard/users/_users.html.erb
@@ -1,11 +1,15 @@
 <% @users.each do |user| %>
   <%= link_to user, class: "card card--narrow card--center" do %>
     <% if user.photo.attached? %>
-      <%= image_tag url_for(user.photo), class: "card__img--circle" %>
+      <% if user.photo.variable? %>
+        <%= image_tag user.photo.variant(resize_to_fill: [300, 300]), class: "card__img--circle", alt: user.display_name, title: user.display_name %>
+      <% else %>
+        <%= image_tag user.photo, class: "card__img--circle", alt: user.display_name, title: user.display_name %>
+      <% end %>
     <% else %>
-      <%= image_tag asset_path("speaker.png"), class: "card__img--circle" %>
+      <%= image_tag asset_path("speaker.png"), class: "card__img--circle", alt: user.display_name, title: user.display_name %>
     <% end %>
-    <div class="card--wrap"><%= user.email %></div>
+    <div class="card--wrap"><%= user.display_name %></div>
     <% if user.role %>
       <div class="badge"><%= User.human_attribute_name("role.#{user.role}") %></div>
     <% end %>

--- a/rails/app/views/dashboard/users/edit.html.erb
+++ b/rails/app/views/dashboard/users/edit.html.erb
@@ -1,17 +1,21 @@
 <% content_for(:title) do %>
-  <%= @user.email %> | <%= t("user") %>
+  <%= @user.display_name %> | <%= t("user") %>
 <% end %>
 
 <% content_for(:main_heading) do %>
   <div class="avatar-card">
     <span class="media-with-hover-controls rounded" data-replace-on-delete="<%= asset_path("speaker.png") %>">
       <% if @user.photo.attached? %>
-        <%= image_tag @user.photo, alt: @user.email, title: @user.email %>
+        <% if @user.photo.variable? %>
+          <%= image_tag @user.photo.variant(resize_to_fill: [300, 300]), alt: @user.display_name, title: @user.display_name  %>
+        <% else %>
+          <%= image_tag @user.photo, alt: @user.display_name, title: @user.display_name %>
+        <% end %>
         <%= link_to user_photo_path(@user), class: "overlay delete-link", method: :delete, data: {confirm: t("dashboard.actions.confirm")}, remote: true do %>
           <span><%= t("dashboard.actions.destroy") %></span>
         <% end %>
       <% else %>
-        <%= image_tag asset_path("speaker.png"), alt: @user.email, title: @user.email %>
+        <%= image_tag asset_path("speaker.png"), alt: @user.display_name, title: @user.display_name %>
       <% end %>
     </span>
   </div>

--- a/rails/app/views/dashboard/users/show.html.erb
+++ b/rails/app/views/dashboard/users/show.html.erb
@@ -1,17 +1,27 @@
 <% content_for(:title) do %>
-  <%= @user.email %> | <%= t("user") %>
+  <%= @user.display_name %> | <%= t("user") %>
 <% end %>
 
 <% content_for(:main_heading) do %>
 <div class="columns">
   <div class="avatar-card">
   <% if @user.photo.attached? %>
-    <%= image_tag @user.photo, class: "img--rounded img--mega", alt: @user.email, title: @user.email %>
+    <% if @user.photo.variable? %>
+      <%= image_tag @user.photo.variant(resize_to_fill: [300, 300]), class: "img--rounded img--mega", alt: @user.display_name, title: @user.display_name %>
+    <% else %>
+      <%= image_tag @user.photo, class: "img--rounded img--mega", alt: @user.display_name, title: @user.display_name %>
+    <% end %>
   <% else %>
-    <%= image_tag asset_path("speaker.png"), class: "img--rounded img--mega", alt: @user.email, title: @user.email %>
+    <%= image_tag asset_path("speaker.png"), class: "img--rounded img--mega", alt: @user.display_name, title: @user.display_name %>
   <% end %>
   <h2>
-    <%= @user.email %>
+    <div class="small">
+      <% if @user.name.present? %>
+        <%= @user.username %> //
+      <% end %>
+      <%= @user.email %>
+    </div>
+    <%= @user.display_name %>
     <div class="small">
       <span class="badge"><%= User.human_attribute_name("role.#{@user.role}") %></span>
     </div>

--- a/rails/app/views/devise/registrations/edit.html.erb
+++ b/rails/app/views/devise/registrations/edit.html.erb
@@ -1,13 +1,23 @@
 <div class="devise">
   <div class="devise-card">
-    <h2>Edit <%= resource_name.to_s.humanize %></h2>
+    <h2><%= t("profile") %></h2>
 
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-      <%= devise_error_messages! %>
+      <%= render "devise/shared/error_messages", resource: resource %>
+
+      <div class="field">
+        <%= f.label :username %>
+        <%= f.text_field :username, autofocus: true, autocomplete: "username" %>
+      </div>
+
+      <div class="field">
+        <%= f.label :name %>
+        <%= f.text_field :name, autocomplete: "name" %>
+      </div>
 
       <div class="field">
         <%= f.label :email %>
-        <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+        <%= f.email_field :email, autocomplete: "email" %>
       </div>
 
       <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>

--- a/rails/app/views/devise/registrations/new.html.erb
+++ b/rails/app/views/devise/registrations/new.html.erb
@@ -3,11 +3,21 @@
     <h2>Sign up</h2>
 
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-      <%= devise_error_messages! %>
+      <%= render "devise/shared/error_messages", resource: resource %>
+
+      <div class="field">
+        <%= f.label :username %>
+        <%= f.text_field :username, autofocus: true, autocomplete: "username" %>
+      </div>
+
+      <div class="field">
+        <%= f.label :name %>
+        <%= f.text_field :name, autocomplete: "name" %>
+      </div>
 
       <div class="field">
         <%= f.label :email %>
-        <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+        <%= f.email_field :email, autocomplete: "email" %>
       </div>
 
       <div class="field">

--- a/rails/app/views/devise/sessions/new.html.erb
+++ b/rails/app/views/devise/sessions/new.html.erb
@@ -15,8 +15,8 @@
       <% end %>
 
       <div class="field">
-        <%= f.label :email %>
-        <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+        <%= f.label :login %>
+        <%= f.text_field :login, autofocus: true %>
       </div>
 
       <div class="field">

--- a/rails/app/views/home/community_search_index.erb
+++ b/rails/app/views/home/community_search_index.erb
@@ -6,6 +6,7 @@
       <p><%= t("community_search.coming_soon") %></p>
       <br/>
       <% if user_signed_in? %>
+        <%= link_to t("profile"), edit_registration_path(current_user) %> |
         <%= link_to t("logout"), destroy_user_session_path, method: :delete, :class => 'navbar-link'  %>
       <% else %>
         <%= link_to t("login"), new_user_session_path, :class => 'navbar-link'  %>

--- a/rails/app/views/layouts/dashboard.html.erb
+++ b/rails/app/views/layouts/dashboard.html.erb
@@ -67,9 +67,13 @@
         <% end %>
         <div class="top-nav">
           <div class="user-nav">
-            <%= current_user.email %>
+            <%= current_user.username %>
             <% if current_user.photo.attached? %>
-              <%= image_tag current_user.photo, class: "img img--rounded img--micro" %>
+              <% if current_user.photo.variable? %>
+                <%= image_tag current_user.photo.variant(resize_to_fill: [300, 300]), class: "img img--rounded img--mini" %>
+              <% else %>
+                <%= image_tag current_user.photo, class: "img img--rounded img--mini" %>
+              <% end %>
             <% else %>
               <%= image_tag asset_path("speaker.png"), class: "img img--rounded img--micro" %>
             <% end %>

--- a/rails/app/views/layouts/dashboard.html.erb
+++ b/rails/app/views/layouts/dashboard.html.erb
@@ -76,7 +76,7 @@
             <ul class="dropdown" aria-label="submenu">
               <% if current_user.super_admin %>
               <% end %>
-              <li><%= link_to t("profile"), edit_user_path(current_user) %></a></li>
+              <li><%= link_to t("profile"), user_profile_path %></a></li>
               <li><%= link_to t("logout"), destroy_user_session_path, method: :delete  %></li>
             </ul>
           </div>

--- a/rails/config/initializers/devise.rb
+++ b/rails/config/initializers/devise.rb
@@ -42,7 +42,7 @@ Devise.setup do |config|
   # session. If you need permissions, you should implement that in a before filter.
   # You can also supply a hash where the value is a boolean determining whether
   # or not authentication should be aborted when the value is not present.
-  # config.authentication_keys = [:email]
+  config.authentication_keys = [:login]
 
   # Configure parameters from the request object used for authentication. Each entry
   # given should be a request method and it will automatically be passed to the
@@ -54,12 +54,12 @@ Devise.setup do |config|
   # Configure which authentication keys should be case-insensitive.
   # These keys will be downcased upon creating or modifying a user and when used
   # to authenticate or find a user. Default is :email.
-  config.case_insensitive_keys = [:email]
+  config.case_insensitive_keys = [:email, :login]
 
   # Configure which authentication keys should have whitespace stripped.
   # These keys will have whitespace before and after removed upon creating or
   # modifying a user and when used to authenticate or find a user. Default is :email.
-  config.strip_whitespace_keys = [:email]
+  config.strip_whitespace_keys = [:email, :login]
 
   # Tell if authentication through request.params is enabled. True by default.
   # It can be set to an array that will enable params authentication only for the

--- a/rails/config/locales/en/models.en.yml
+++ b/rails/config/locales/en/models.en.yml
@@ -7,6 +7,7 @@ en:
       invalid_zoom_level: value should be between 0 and 22
       invalid_pitch: value should be 0 and 85
       invalid_bearing: value should be between -180 and 180
+      invalid_username_format: cannot contain spaces
   helpers:
     label:
       place:
@@ -98,6 +99,9 @@ en:
         pitch: Pitch degree
         bearing: Bearing degress
       user:
+        login: Username or Email
+        name: Display Name
+        username: Username
         email: Email
         role: Role
         password: Password

--- a/rails/config/locales/es/models.es.yml
+++ b/rails/config/locales/es/models.es.yml
@@ -98,6 +98,9 @@ es:
         pitch: Grado de tono
         bearing: Grado de orientación
       user:
+        login: Username or Email
+        name: Display Name
+        username: Username
         email: Correo electrónico
         role: Rol
         password: Contraseña

--- a/rails/config/locales/ja/models.ja.yml
+++ b/rails/config/locales/ja/models.ja.yml
@@ -98,6 +98,9 @@ ja:
         pitch: Pitch degree
         bearing: Bearing degress
       user:
+        login: Username or Email
+        name: Display Name
+        username: Username
         email: Email
         role: ロール
         password: パスワード

--- a/rails/config/locales/mat/models.mat.yml
+++ b/rails/config/locales/mat/models.mat.yml
@@ -98,6 +98,9 @@ mat:
         pitch: Pitch degree
         bearing: Bearing degress
       user:
+        login: Username or Email
+        name: Display Name
+        username: Username
         email: Email
         role: Rol
         password: Paswoord

--- a/rails/config/locales/nl/models.nl.yml
+++ b/rails/config/locales/nl/models.nl.yml
@@ -98,6 +98,9 @@ nl:
         pitch: Pitch degree
         bearing: Bearing degress
       user:
+        login: Username or Email
+        name: Display Name
+        username: Username
         email: Email
         role: Rol
         password: Paswoord

--- a/rails/config/locales/pt/models.pt.yml
+++ b/rails/config/locales/pt/models.pt.yml
@@ -98,6 +98,9 @@ pt:
         pitch: Grau de pitch
         bearing: Grau de rolamento
       user:
+        login: Username or Email
+        name: Display Name
+        username: Username
         email: Email
         role: Função
         password: Senha

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
 
         get :search, to: "search#index"
 
+        get :profile, to: "users#profile", as: :user_profile
         resources :users do
           delete :photo, action: :delete_photo
         end

--- a/rails/db/migrate/20221004183628_add_fields_to_users.rb
+++ b/rails/db/migrate/20221004183628_add_fields_to_users.rb
@@ -1,4 +1,4 @@
-class AddFieldsToUsers < ActiveRecord::Migration[6.1]
+class AddFieldsToUsers < ActiveRecord::Migration[6.0]
   def up
     # don't set default/null when adding column to avoid excessive writes
     add_column :users, :username, :string

--- a/rails/db/migrate/20221004183628_add_fields_to_users.rb
+++ b/rails/db/migrate/20221004183628_add_fields_to_users.rb
@@ -1,0 +1,38 @@
+class AddFieldsToUsers < ActiveRecord::Migration[6.1]
+  def up
+    # don't set default/null when adding column to avoid excessive writes
+    add_column :users, :username, :string
+    add_column :users, :name, :string
+
+    # automatically set all users usernames to their email for backwards compat
+    User.where(username: nil).find_each do |user|
+      user.update(username: user.email)
+    end
+
+    # now set default and null
+    change_column_default :users, :username, ""
+    change_column_null :users, :username, false
+
+    # and index
+    add_index :users, :username, unique: true
+
+    # and allow email to be nil
+    change_column_default :users, :email, nil
+    change_column_null :users, :email, true
+  end
+
+  def down
+    User.where(email: [nil, ""]).find_each do |user|
+      user.email = user.username
+      user.save!(validate: false)
+    end
+
+    # Remove new columns
+    remove_column :users, :username
+    remove_column :users, :name
+
+    # Revert default and null on email
+    change_column_default :users, :email, ""
+    change_column_null :users, :email, false
+  end
+end

--- a/rails/db/schema.rb
+++ b/rails/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_28_202901) do
+ActiveRecord::Schema.define(version: 2022_10_04_183628) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -154,8 +154,11 @@ ActiveRecord::Schema.define(version: 2022_09_28_202901) do
     t.integer "role"
     t.integer "community_id"
     t.boolean "super_admin", default: false, null: false
+    t.string "username", default: "", null: false
+    t.string "name"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["username"], name: "index_users_on_username", unique: true
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/rails/db/schema.rb
+++ b/rails/db/schema.rb
@@ -139,7 +139,7 @@ ActiveRecord::Schema.define(version: 2022_10_04_183628) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string "email", default: "", null: false
+    t.string "email"
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"

--- a/rails/db/seeds.rb
+++ b/rails/db/seeds.rb
@@ -8,6 +8,7 @@
 
 # Super Admin user for Terrastories
 User.find_or_create_by!(email: "super@terrastories.io") do |admin|
+  admin.username = 'terrastories-super'
   admin.password = 'terrastories'
   admin.password_confirmation = 'terrastories'
   admin.role = 100
@@ -94,6 +95,7 @@ atalm2022_story = Story.find_or_create_by(title: "ATALM 2022",
 
 # Create an admin user for example community
 User.find_or_create_by!(email: 'admin@terrastories.io') do |admin|
+  admin.username = 'terrastories-admin'
   admin.password = 'terrastories'
   admin.password_confirmation = 'terrastories'
   admin.role = 2
@@ -102,6 +104,7 @@ end
 
 # Create an editor user for example community
 User.find_or_create_by!(email: 'editor@terrastories.io') do |admin|
+  admin.username = 'terrastories-editor'
   admin.password = 'terrastories'
   admin.password_confirmation = 'terrastories'
   admin.role = 1
@@ -110,6 +113,7 @@ end
 
 # Create a member user for example community
 User.find_or_create_by!(email: 'user@terrastories.io') do |admin|
+  admin.username = 'terrastories-user'
   admin.password = 'terrastories'
   admin.password_confirmation = 'terrastories'
   admin.role = 0
@@ -118,6 +122,7 @@ end
 
 # Create a viewer user for example community
 User.find_or_create_by!(email: 'viewer@terrastories.io') do |user|
+  user.username = 'terrastories-viewer'
   user.password = 'terrastories'
   user.password_confirmation = 'terrastories'
   user.role = 3
@@ -126,6 +131,7 @@ end
 
 # Public user, not associated with Community
 User.find_or_create_by!(email: "public@terrastories.io") do |admin|
+  admin.username = 'terrastories-public'
   admin.password = 'terrastories'
   admin.password_confirmation = 'terrastories'
   admin.role = 100


### PR DESCRIPTION
Resolves #797
Resolves #793

This adds the ability for a user to sign in with a username instead of an email. Logging in with email still works!

For backwards compatibility, this saves the user's current email to the username attribute. The migration is reversible, even after adding new users with usernames without email addresses.

Additionally, this:

1. Fixes an issue with images not displaying correctly across the dashboard (found during user updates)
2. Adds a new /profile route for the current user to manage their own user profile without needing to display user ID in the route; only available in the dropdown in email
3. Adds username AND name field to User. App will display name when available and fallback to username.
4. Fixes a flash message error where things would be unclickable underneath an invisible element.5. 
5. Updates Devise registration new and edit forms to allow sign up and account update with new attributes.6. 
6. Updates Welcome / No-Community user to add a profile link to update their profile information.

https://user-images.githubusercontent.com/2660801/193943464-b9e7422c-e433-4180-82ca-afbf5e9819a8.mp4


