### PR TITLE
Truncates speaker and place name to 30 characters in the story filters

### DIFF
--- a/rails/app/views/dashboard/stories/index.html.erb
+++ b/rails/app/views/dashboard/stories/index.html.erb
@@ -10,11 +10,11 @@
   <%= form_with url: stories_path, method: :get, class: "filters", local: true do |f| %>
     <div>
     <%= f.label :place, t("place") %>
-    <%= f.collection_select :place, community.places, :id, :name, include_blank: t("filter.all"), selected: params[:place] %>
+    <%= f.collection_select :place, community.places, :id, lambda { |place| place.name.truncate(30) }, include_blank: t("filter.all"), selected: params[:place] %>
     </div>
     <div>
     <%= f.label :speaker, t("speaker") %>
-    <%= f.collection_select :speaker, community.speakers, :id, :name, include_blank: t("filter.all"), selected: params[:speaker] %>
+    <%= f.collection_select :speaker, community.speakers, :id, lambda { |speaker| speaker.name.truncate(30) }, include_blank: t("filter.all"), selected: params[:speaker] %>
     </div>
     <% unless current_user.viewer? %>
       <div>


### PR DESCRIPTION
Resolves #822 

Truncates the speaker and place names in the story filters to a maximum of 30 characters to prevent filter fields getting too long.