### PR TITLE
fix: add NL and MAT (fallback) translations, plus small changes to other languages

### DIFF
--- a/rails/config/locales/en/models.en.yml
+++ b/rails/config/locales/en/models.en.yml
@@ -95,7 +95,7 @@ en:
         ne_boundary_lat: Max Latitude
         ne_boundary_long: Max Longitude
         zoom: Zoom level
-        pitch: Pitch degree
+        pitch: Pitch degrees
         bearing: Bearing degrees
         map_projection: Set projection for map
       user:

--- a/rails/config/locales/ja/models.ja.yml
+++ b/rails/config/locales/ja/models.ja.yml
@@ -95,7 +95,7 @@ ja:
         ne_boundary_lat: Max Latitude
         ne_boundary_long: Max Longitude
         zoom: Zoom level
-        pitch: Pitch degree
+        pitch: Pitch degrees
         bearing: Bearing degrees
         map_projection: Set projection for map
       user:

--- a/rails/config/locales/mat/dashboard.mat.yml
+++ b/rails/config/locales/mat/dashboard.mat.yml
@@ -1,17 +1,17 @@
 mat:
-  profile: Profile
+  profile: Profiel
   interviewer: Interviewer
-  import: Import
+  import: Importeer
   map:
-    center: Map Center
-    bounds: Map Bounds
-    bounds_description: The boundaries of the map determine the extent of where you can scroll on the map. Unrestricted, the map will be infinitely scrollable.
-    sw_corner: Southwest Corner
-    ne_corner: Northeast Corner
-    unrestricted_bounds: Allow unrestricted bounds
-    online: Online Map Configuration
-    settings: Map Settings
-    settings_description: Customize your community's map settings.
+    center: Kaart Center
+    bounds: Kaartgrenzen
+    bounds_description: De grenzen van de kaart bepalen de mate waarin u op de kaart kunt scrollen. Zonder grenzen, de kaart is onbeperkt scrollbaar.
+    sw_corner: Zuidwest Hoek
+    ne_corner: Noordoost Hoek
+    unrestricted_bounds: Onbeperkte grenzen toestaan
+    online: Online Kaartconfiguratie
+    settings: Kaartconfiguratie
+    settings_description: Pas de kaartinstellingen van uw community aan.
     projection:
       mercator: Mercator
       albers: Albers
@@ -21,8 +21,8 @@ mat:
       naturalEarth: Natural Earth
       winkelTripel: Winkel Tripel
   dashboard:
-    back_to_app: Back to App
-    community_settings: Community Settings
+    back_to_app: Terug naar App
+    community_settings: Gemeenschap instellingen
     headings:
       new_resource: Nieuw %{name}
     actions:
@@ -33,21 +33,21 @@ mat:
       back: Terug
       show_resource: Toon %{name}
     theme:
-      welcome_screen: Welcome Screen
-      background_img: Customize the background image on the landing page of your community.
-      sponsor_logos: Display logos on your community page. This could be your organization's logo, or that of a project sponsor. Multiple logos can be added.
+      welcome_screen: Welkomscherm
+      background_img: Pas de achtergrondafbeelding op de bestemmingspagina van uw community aan.
+      sponsor_logos: Geef logo's weer op uw communitypagina. Dit kan het logo van uw organisatie zijn, of dat van een projectsponsor. Er kunnen meerdere logo's worden toegevoegd.
   search:
     clear: Verwijder
     label: Zoeken
     heading: Zoeken resultaten
     results: resultaten
   filter:
-    all: All
-    any: Any
+    all: Alles
+    any: Ieder
     label: Filter
-    clear: Clear Filters
+    clear: Filters wissen
   list:
-    prev: Prev
-    next: Next
-    no_results: There are no %{resources} available.
-    no_nested_results: This %{resource} has no %{resources}.
+    prev: Vorig
+    next: Volgende
+    no_results: Er zijn geen %{resources} beschikbaar.
+    no_nested_results: Deze %{resource} heeft geen %{resources}.

--- a/rails/config/locales/mat/mat.yml
+++ b/rails/config/locales/mat/mat.yml
@@ -18,7 +18,7 @@ mat:
   alphabetical: "A-Z"
   back_to_map: "Go ko na kaita"
   back_to_welcome: "Go ko na bigi"
-  built_with_love: Built with ❤️ by
+  built_with_love: Meki ku ❤️ fu
   close: "Tapa"
   community_search:
     title: "Zoek een community om te verkennen"

--- a/rails/config/locales/mat/models.mat.yml
+++ b/rails/config/locales/mat/models.mat.yml
@@ -1,42 +1,42 @@
 mat:
   errors:
     messages:
-      map_bounds: All four bounding box values must be set, or left blank
-      invalid_latitude: value should be between -90 and 90
-      invalid_longitude: value should be between -180 and 180
-      invalid_zoom_level: value should be between 0 and 22
-      invalid_pitch: value should be 0 and 85
-      invalid_bearing: value should be between -180 and 180
+      map_bounds: Alle vier de kaart grenzen moeten worden ingesteld of leeg worden gelaten
+      invalid_latitude: de waarde moet tussen -90 en 90 zijn
+      invalid_longitude: de waarde moet tussen -180 en 180 zijn
+      invalid_zoom_level: de waarde moet tussen 0 en 22 zijn
+      invalid_pitch: de waarde moet tussen 0 en 85 zijn
+      invalid_bearing: de waarde moet tussen -180 en 180 zijn
   helpers:
     label:
       place:
         one: Plaats
       speaker:
         one: Spreker
-      visibility: Visibility
+      visibility: Zichtbaarheid
   activerecord:
     errors:
       models:
         place:
           attributes:
             name_audio:
-              content_type: content type is not in list
+              content_type: inhoudstype staat niet in lijst
             photo:
-              content_type: content type is not in list
+              content_type: inhoudstype staat niet in lijst
         story:
           attributes:
             place_ids:
-              blank: Your story must have a Place
+              blank: Uw verhaal moet een plaats hebben
             speaker_ids:
-              blank: Your story must have at least one Speaker
+              blank: Uw verhaal moet tenminste een Spreker hebben
         theme:
           attributes:
             background_img:
-              content_type: content type is not in list
+              content_type: inhoudstype staat niet in lijst
             mapbox_access_token:
-              blank: is required when the Mapbox style URL is set.
+              blank: is vereist wanneer de URL van de Mapbox-stijl is ingesteld.
             mapbox_style_url:
-              blank: is required when the Mapbox access token is set.
+              blank: is vereist wanneer het Mapbox-toegangstoken is ingesteld.
     # Used to auto-translate submit buttons
     models:
       community: Gemeenschap
@@ -51,7 +51,7 @@ mat:
     attributes:
       place:
         name: Naam
-        name_audio: Placename Audio
+        name_audio: Plaatsnaam Audio
         description: Omschrijving
         type_of_place: Soort plaats
         region: Regio
@@ -83,22 +83,25 @@ mat:
         user_only: Lid
         editor_only: Editor
       theme:
-        background_img: Background image
-        sponsor_logos: Sponsor logos
-        mapbox_style_url: Mapbox style URL
-        mapbox_access_token: Mapbox access token associated with the style
-        mapbox_3d: Activate 3D Terrain view for online map
-        center_lat: Latitude
-        center_long: Longitude
-        sw_boundary_lat: Min Latitude
-        sw_boundary_long: Min Longitude
-        ne_boundary_lat: Max Latitude
-        ne_boundary_long: Max Longitude
-        zoom: Zoom level
-        pitch: Pitch degree
-        bearing: Bearing degrees
-        map_projection: Set projection for map
+        background_img: Achtergrondafebeeldng
+        sponsor_logos: Sponsorlogo's
+        mapbox_style_url: Mapbox stijl URL
+        mapbox_access_token: Mapbox toegangstoken gekoppeld aan de stijl
+        mapbox_3d: Activeer 3D Terrainweergave voor de online kaart
+        center_lat: Breedtegraad
+        center_long: Lengtegraad
+        sw_boundary_lat: Min Breedtegraad
+        sw_boundary_long: Min Lengtegraad
+        ne_boundary_lat: Max Breedtegraad
+        ne_boundary_long: Max Lengtegraad
+        zoom: Zoomniveau
+        pitch: Hoogtegraad
+        bearing: Lagergraden
+        map_projection: Projectie instellen voor kaart
       user:
+        login: Gebruikersnaam of Email
+        name: Weergavenaam
+        username: Gebruikersnaam
         email: Email
         role: Rol
         password: Paswoord

--- a/rails/config/locales/nl/dashboard.nl.yml
+++ b/rails/config/locales/nl/dashboard.nl.yml
@@ -1,17 +1,17 @@
 nl:
-  profile: Profile
+  profile: Profiel
   interviewer: Interviewer
-  import: Import
+  import: Importeer
   map:
-    center: Map Center
-    bounds: Map Bounds
-    bounds_description: The boundaries of the map determine the extent of where you can scroll on the map. Unrestricted, the map will be infinitely scrollable.
-    sw_corner: Southwest Corner
-    ne_corner: Northeast Corner
-    unrestricted_bounds: Allow unrestricted bounds
-    online: Online Map Configuration
-    settings: Map Settings
-    settings_description: Customize your community's map settings.
+    center: Kaart Center
+    bounds: Kaartgrenzen
+    bounds_description: De grenzen van de kaart bepalen de mate waarin u op de kaart kunt scrollen. Zonder grenzen, de kaart is onbeperkt scrollbaar.
+    sw_corner: Zuidwest Hoek
+    ne_corner: Noordoost Hoek
+    unrestricted_bounds: Onbeperkte grenzen toestaan
+    online: Online Kaartconfiguratie
+    settings: Kaartconfiguratie
+    settings_description: Pas de kaartinstellingen van uw community aan.
     projection:
       mercator: Mercator
       albers: Albers
@@ -21,8 +21,8 @@ nl:
       naturalEarth: Natural Earth
       winkelTripel: Winkel Tripel
   dashboard:
-    back_to_app: Back to App
-    community_settings: Community Settings
+    back_to_app: Terug naar App
+    community_settings: Gemeenschap instellingen
     headings:
       new_resource: Nieuw %{name}
     actions:
@@ -33,21 +33,21 @@ nl:
       back: Terug
       show_resource: Toon %{name}
     theme:
-      welcome_screen: Welcome Screen
-      background_img: Customize the background image on the landing page of your community.
-      sponsor_logos: Display logos on your community page. This could be your organization's logo, or that of a project sponsor. Multiple logos can be added.
+      welcome_screen: Welkomscherm
+      background_img: Pas de achtergrondafbeelding op de bestemmingspagina van uw community aan.
+      sponsor_logos: Geef logo's weer op uw communitypagina. Dit kan het logo van uw organisatie zijn, of dat van een projectsponsor. Er kunnen meerdere logo's worden toegevoegd.
   search:
     clear: Verwijder
     label: Zoeken
     heading: Zoeken resultaten
     results: resultaten
   filter:
-    all: All
-    any: Any
+    all: Alles
+    any: Ieder
     label: Filter
-    clear: Clear Filters
+    clear: Filters wissen
   list:
-    prev: Prev
-    next: Next
-    no_results: There are no %{resources} available.
-    no_nested_results: This %{resource} has no %{resources}.
+    prev: Vorig
+    next: Volgende
+    no_results: Er zijn geen %{resources} beschikbaar.
+    no_nested_results: Deze %{resource} heeft geen %{resources}.

--- a/rails/config/locales/nl/models.nl.yml
+++ b/rails/config/locales/nl/models.nl.yml
@@ -1,42 +1,42 @@
 nl:
   errors:
     messages:
-      map_bounds: All four bounding box values must be set, or left blank
-      invalid_latitude: value should be between -90 and 90
-      invalid_longitude: value should be between -180 and 180
-      invalid_zoom_level: value should be between 0 and 22
-      invalid_pitch: value should be 0 and 85
-      invalid_bearing: value should be between -180 and 180
+      map_bounds: Alle vier de kaart grenzen moeten worden ingesteld of leeg worden gelaten
+      invalid_latitude: de waarde moet tussen -90 en 90 zijn
+      invalid_longitude: de waarde moet tussen -180 en 180 zijn
+      invalid_zoom_level: de waarde moet tussen 0 en 22 zijn
+      invalid_pitch: de waarde moet tussen 0 en 85 zijn
+      invalid_bearing: de waarde moet tussen -180 en 180 zijn
   helpers:
     label:
       place:
         one: Plaats
       speaker:
         one: Spreker
-      visibility: Visibility
+      visibility: Zichtbaarheid
   activerecord:
     errors:
       models:
         place:
           attributes:
             name_audio:
-              content_type: content type is not in list
+              content_type: inhoudstype staat niet in lijst
             photo:
-              content_type: content type is not in list
+              content_type: inhoudstype staat niet in lijst
         story:
           attributes:
             place_ids:
-              blank: Your story must have a Place
+              blank: Uw verhaal moet een plaats hebben
             speaker_ids:
-              blank: Your story must have at least one Speaker
+              blank: Uw verhaal moet tenminste een Spreker hebben
         theme:
           attributes:
             background_img:
-              content_type: content type is not in list
+              content_type: inhoudstype staat niet in lijst
             mapbox_access_token:
-              blank: is required when the Mapbox style URL is set.
+              blank: is vereist wanneer de URL van de Mapbox-stijl is ingesteld.
             mapbox_style_url:
-              blank: is required when the Mapbox access token is set.
+              blank: is vereist wanneer het Mapbox-toegangstoken is ingesteld.
     # Used to auto-translate submit buttons
     models:
       community: Gemeenschap
@@ -51,7 +51,7 @@ nl:
     attributes:
       place:
         name: Naam
-        name_audio: Placename Audio
+        name_audio: Plaatsnaam Audio
         description: Omschrijving
         type_of_place: Soort plaats
         region: Regio
@@ -83,22 +83,25 @@ nl:
         user_only: Lid
         editor_only: Editor
       theme:
-        background_img: Background image
-        sponsor_logos: Sponsor logos
-        mapbox_style_url: Mapbox style URL
-        mapbox_access_token: Mapbox access token associated with the style
-        mapbox_3d: Activate 3D Terrain view for online map
-        center_lat: Latitude
-        center_long: Longitude
-        sw_boundary_lat: Min Latitude
-        sw_boundary_long: Min Longitude
-        ne_boundary_lat: Max Latitude
-        ne_boundary_long: Max Longitude
-        zoom: Zoom level
-        pitch: Pitch degree
-        bearing: Bearing degrees
+        background_img: Achtergrondafebeeldng
+        sponsor_logos: Sponsorlogo's
+        mapbox_style_url: Mapbox stijl URL
+        mapbox_access_token: Mapbox toegangstoken gekoppeld aan de stijl
+        mapbox_3d: Activeer 3D Terrainweergave voor de online kaart
+        center_lat: Breedtegraad
+        center_long: Lengtegraad
+        sw_boundary_lat: Min Breedtegraad
+        sw_boundary_long: Min Lengtegraad
+        ne_boundary_lat: Max Breedtegraad
+        ne_boundary_long: Max Lengtegraad
+        zoom: Zoomniveau
+        pitch: Hoogtegraad
+        bearing: Lagergraden
         map_projection: Projectie instellen voor kaart
       user:
+        login: Gebruikersnaam of Email
+        name: Weergavenaam
+        username: Gebruikersnaam
         email: Email
         role: Rol
         password: Paswoord

--- a/rails/config/locales/pt/models.pt.yml
+++ b/rails/config/locales/pt/models.pt.yml
@@ -97,6 +97,7 @@ pt:
         zoom: Nivel de zoom
         pitch: Grau de pitch
         bearing: Grau de rolamento
+        map_projection: Definir projeção para o mapa
       user:
         email: Email
         role: Função

--- a/rails/config/locales/pt/pt.yml
+++ b/rails/config/locales/pt/pt.yml
@@ -18,7 +18,7 @@ pt:
   alphabetical: "A-Z"
   back_to_map: "Volta ao mapa"
   back_to_welcome: "Voltar para a página de inicial"
-  built_with_love: Built with ❤️ by
+  built_with_love: Construído com ❤️ por
   close: "Fechar"
   community_search:
     title: "Procure por uma Comunidade para explorar"


### PR DESCRIPTION
This PR adds Dutch (NL) translations for all strings (except Administrate since we are scrapping that soon), and also adds those translations as a fallback for Matawai. Plus a few minor updates for the other languages.

https://github.com/Terrastories/terrastories/issues/826