### PR TITLE
feat: support globe projection

### DIFF
--- a/documentation/CUSTOMIZATION.md
+++ b/documentation/CUSTOMIZATION.md
@@ -28,7 +28,7 @@ _**Note:** when using Mapbox.com maps with Terrastories, you are subject to Mapb
 
 It is possible to set a custom map extent, zoom level, pitch, and boundaries of the Terrastories map.
 
-You can also set the map projection for your map to one of [the projections supported by Mapbox](https://docs.mapbox.com/help/glossary/projection/). The new Globe projection will be added when it is possible to do so.
+You can also set the map projection for your map to one of [the projections supported by Mapbox](https://docs.mapbox.com/help/glossary/projection/).
 
 For online Terrastories maps, you can toggle on/off a realistic Mapbox 3D Terrain layer to view your maps in 3D. 3D Terrain adds another level of detail to the landscape, but requires more map and tile loading and therefore can impact the overall performance of Terrastories on your device.
 

--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -100,6 +100,6 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
-gem 'mapbox-gl-rails'
+gem 'mapbox-gl-rails', '~> 2.9.0'
 gem 'aws-sdk-s3'
 gem 'activestorage-validator'

--- a/rails/app/assets/stylesheets/application.scss
+++ b/rails/app/assets/stylesheets/application.scss
@@ -1,3 +1,8 @@
+// this handler function is implemented here because mapbox-gl-rails uses modern css syntax which sass can't interpet.
+@function rgb($args...) {
+    @return r#{g}#{b}(#{$args})
+  }
+
 @import 'mapbox-gl';
 @import 'plyr';
 @import 'core/core';

--- a/rails/app/assets/stylesheets/dashboard.scss
+++ b/rails/app/assets/stylesheets/dashboard.scss
@@ -1,3 +1,8 @@
+// this handler function is implemented here because mapbox-gl-rails uses modern css syntax which sass can't interpet.
+@function rgb($args...) {
+  @return r#{g}#{b}(#{$args})
+}
+
 @import 'core/reset';
 @import 'core/variables';
 @import 'core/colors';

--- a/rails/app/dashboards/theme_dashboard.rb
+++ b/rails/app/dashboards/theme_dashboard.rb
@@ -100,6 +100,6 @@ class ThemeDashboard < Administrate::BaseDashboard
   end
 
   def permitted_attributes
-    super + [:sponsor_logos => [], map_projection: [:mercator, :albers, :equalEarth, :equirectangular, :lambertConformalConic, :naturalEarth, :winkelTripel]]
+    super + [:sponsor_logos => [], map_projection: [:mercator, :albers, :equalEarth, :equirectangular, :lambertConformalConic, :naturalEarth, :winkelTripel, :globe]]
   end
 end

--- a/rails/app/javascript/components/Map.jsx
+++ b/rails/app/javascript/components/Map.jsx
@@ -127,7 +127,6 @@ export default class Map extends Component {
       }
 
       if(!this.props.useLocalMapServer && this.props.mapProjection == "globe") {
-        console.log(this.props.mapProjection);
         this.map.setFog({
           'horizon-blend': 0.02,
           'star-intensity': 0.15,

--- a/rails/app/javascript/components/Map.jsx
+++ b/rails/app/javascript/components/Map.jsx
@@ -126,6 +126,17 @@ export default class Map extends Component {
         });
       }
 
+      if(!this.props.useLocalMapServer && this.props.mapProjection == "globe") {
+        console.log(this.props.mapProjection);
+        this.map.setFog({
+          'horizon-blend': 0.02,
+          'star-intensity': 0.15,
+          'color': '#ffffff',
+          'high-color': '#008cff',
+          'space-color': '#000000'
+      });
+      } 
+
       this.addHomeButton();
 
       // Attaches popups + events

--- a/rails/app/models/theme.rb
+++ b/rails/app/models/theme.rb
@@ -67,7 +67,7 @@ class Theme < ApplicationRecord
     errors.add(:ne_boundary_long, :invalid_longitude) unless (-180..180).include?(ne_boundary_long)
   end
 
-  enum map_projection: [:mercator, :albers, :equalEarth, :equirectangular, :lambertConformalConic, :naturalEarth, :winkelTripel] 
+  enum map_projection: [:mercator, :albers, :equalEarth, :equirectangular, :lambertConformalConic, :naturalEarth, :winkelTripel, :globe] 
 end
 
 # == Schema Information

--- a/rails/config/locales/en/dashboard.en.yml
+++ b/rails/config/locales/en/dashboard.en.yml
@@ -20,6 +20,7 @@ en:
       lambertConformalConic: Lambert Comformal Conic
       naturalEarth: Natural Earth
       winkelTripel: Winkel Tripel
+      globe: Globe
   dashboard:
     back_to_app: Back to App
     community_settings: Community Settings

--- a/rails/config/locales/es/dashboard.es.yml
+++ b/rails/config/locales/es/dashboard.es.yml
@@ -20,6 +20,7 @@ es:
       lambertConformalConic: Cónica conforme de Lambert
       naturalEarth: Tierra natural
       winkelTripel: Winkel Tripel
+      globe: Globo
   dashboard:
     back_to_app: Regresar a la aplicación
     community_settings: Configuraciones de la comunidad

--- a/rails/config/locales/ja/dashboard.ja.yml
+++ b/rails/config/locales/ja/dashboard.ja.yml
@@ -20,6 +20,7 @@ ja:
       lambertConformalConic: Lambert Comformal Conic
       naturalEarth: Natural Earth
       winkelTripel: Winkel Tripel
+      globe: Globe
   dashboard:
     back_to_app: Back to App
     community_settings: Community Settings

--- a/rails/config/locales/mat/dashboard.mat.yml
+++ b/rails/config/locales/mat/dashboard.mat.yml
@@ -20,6 +20,7 @@ mat:
       lambertConformalConic: Lambert Comformal Conic
       naturalEarth: Natural Earth
       winkelTripel: Winkel Tripel
+      globe: Wereldbol
   dashboard:
     back_to_app: Back to App
     community_settings: Community Settings

--- a/rails/config/locales/nl/dashboard.nl.yml
+++ b/rails/config/locales/nl/dashboard.nl.yml
@@ -20,6 +20,7 @@ nl:
       lambertConformalConic: Lambert Comformal Conic
       naturalEarth: Natural Earth
       winkelTripel: Winkel Tripel
+      globe: Wereldbol
   dashboard:
     back_to_app: Back to App
     community_settings: Community Settings

--- a/rails/config/locales/pt/dashboard.pt.yml
+++ b/rails/config/locales/pt/dashboard.pt.yml
@@ -21,6 +21,7 @@ pt:
       lambertConformalConic: Lambert Comformal Conic
       naturalEarth: Natural Earth
       winkelTripel: Winkel Tripel
+      globe: Globo
   dashboard:
     back_to_app: Back to App
     community_settings: Community Settings


### PR DESCRIPTION
Workaround for https://github.com/Terrastories/terrastories/issues/792

This PR adds the ability to set the map projection to `globe`. 

This was previously not added because of a conflict between the `mapbox-gl-rails` and `sass-rails` gems - the former introduced modern css syntax in the latest version, which is not supported in sass. I added a quick handler function to the relevant css files which use mapbox to rewrite the css in question as a workaround.

Terrastories `dev` profile with an online Mapbox map in globe view:

![Screenshot 2022-10-06 171333](https://user-images.githubusercontent.com/31662219/194444186-1163d846-27ac-4358-81c2-084cdbfb9451.jpg)

Terrastories `offline` profile with locally hosted tiles served with TileServer-GL in globe view:

![Screenshot from 2022-10-06 20-52-41](https://user-images.githubusercontent.com/31662219/194444251-846b8682-9635-47d3-aa07-d15a0c7743d5.png)
