### PR TITLE
fix: format and add `username` field to create community form

### DIFF
--- a/rails/app/controllers/dashboard/communities_controller.rb
+++ b/rails/app/controllers/dashboard/communities_controller.rb
@@ -85,6 +85,7 @@ module Dashboard
         :country,
         :locale,
         users_attributes: [
+          :username,
           :email,
           :password,
           :role

--- a/rails/app/views/dashboard/communities/_form.html.erb
+++ b/rails/app/views/dashboard/communities/_form.html.erb
@@ -1,8 +1,8 @@
-<%= form_with model: @community, multipart: true, data: {remote: false} do |f| %>
+<%= form_with model: @community, multipart: true, data: {remote: false}, class: "form" do |f| %>
   <%= render partial: "shared/form_errors", locals: { resource: @community } %>
 
-  <%= f.label :name %>
-  <%= f.text_field :name %>
+  <%= f.label :name, class: "required" %>
+  <%= f.text_field :name, required: true %>
 
   <%= f.label :country %>
   <%= f.text_field :country %>
@@ -12,11 +12,14 @@
 
   <% if @community.new_record? %>
     <%= f.fields_for :users, User.new do |user_fields| %>
-      <%= user_fields.label :username %>
-      <%= user_fields.text_field :username %>
+      <%= user_fields.label :username, class: "required" %>
+      <%= user_fields.text_field :username, required: true %>
 
-      <%= user_fields.label :password %>
-      <%= user_fields.password_field :password %>
+      <%= user_fields.label :password, class: "required" %>
+      <%= user_fields.password_field :password, required: true %>
+
+      <%= user_fields.label :email %>
+      <%= user_fields.text_field :email %>
 
       <%= user_fields.hidden_field :role, value: "admin" %>
     <% end %>

--- a/rails/app/views/dashboard/communities/_form.html.erb
+++ b/rails/app/views/dashboard/communities/_form.html.erb
@@ -12,8 +12,8 @@
 
   <% if @community.new_record? %>
     <%= f.fields_for :users, User.new do |user_fields| %>
-      <%= user_fields.label :email %>
-      <%= user_fields.text_field :email %>
+      <%= user_fields.label :username %>
+      <%= user_fields.text_field :username %>
 
       <%= user_fields.label :password %>
       <%= user_fields.password_field :password %>


### PR DESCRIPTION
This PR formats, and adds a `username` field to the super-admin's create community form.

Without the `username` field (as a now required field for users), super admin is not able to create any communities as it flashes an error upon saving `Users username can't be blank`.

![image](https://user-images.githubusercontent.com/31662219/194570053-41ce1c47-c76f-4af7-a356-603058a93ba8.png)