### PR TITLE
fix: show username instead of email on super-admin community dashboard

### DIFF
--- a/rails/app/views/dashboard/communities/show.html.erb
+++ b/rails/app/views/dashboard/communities/show.html.erb
@@ -19,14 +19,14 @@
 <table>
   <thead>
     <tr>
-      <th><%= User.human_attribute_name("email") %></th>
+      <th><%= User.human_attribute_name("username") %></th>
       <th><%= User.human_attribute_name("role") %></th>
     </tr>
   </thead>
   <tbody>
     <% @community.users.each do |user| %>
       <tr>
-        <td><%= user.email %></td>
+        <td><%= user.username %></td>
         <td><%= User.human_attribute_name("role.#{user.role}") %></td>
       </tr>
     <% end %>


### PR DESCRIPTION
Show `username` instead of `email` on the super admin community dashboard view.

![image](https://user-images.githubusercontent.com/31662219/194574568-adc57563-bb7f-4002-8d72-48ec0e6a90e7.png)
