### PR TITLE
Added Swahili translation for the administrate file

### DIFF
--- a/rails/config/locales/sw/administrate.sw.yml
+++ b/rails/config/locales/sw/administrate.sw.yml
@@ -1,0 +1,140 @@
+---
+sw:
+  helpers:
+    label:
+      speaker:
+        name: Jina
+        speaker_community: Jumuiya ya mzungumzaji
+        birthdate: Tarehe ya kuzaliwa
+        birthplace: Pahali pa kuzaliwa
+        story_ids: Hadithi
+      story:
+        desc: Maelezo
+        interviewer: Mhojaji
+        video_unsupported: Samahani, kivinjari chako hakitumii video zilizopachikwa.
+        permissions:
+          anonymous: "Inaweza kutafutwa"
+          user_only: "Mwanachama"
+          editor_only: "Mhariri"
+          admin_only: "Msimamizi"
+        place_ids: Maeneo
+        speaker_ids: Wazungumzaji
+      place:
+        lat: Latitudo
+        long: Longitudo
+        name: Jina
+        name_audio: Sauti ya Jina la mahali
+        description: Maelezo
+        type_of_place: Aina ya mahali
+        region: Eneo
+        story_ids: Hadithi
+      theme:
+        background_img: Picha ya Mandharinyuma (kwa skrini ya kukaribisha)
+        sponsor_logos: Nembo za wafadhili (kwa skrini ya kukaribisha)
+        mapbox_style_url: URL ya mtindo wa kisanduku cha ramani (ya ramani za mtandaoni)
+        mapbox_access_token: Tokeni ya ufikiaji ya kisanduku cha ramani inayohusishwa na mtindo
+        mapbox_3d: Washa mwonekano wa 3D kwa ramani ya mtandaoni
+        map_projection: Weka makadirio ya ramani
+        center_lat: Kituo cha ramani, latitudo
+        center_long: Kituo cha ramani, longitudo
+        sw_boundary_lat: Sanduku la kufunga la SW, latitudo (si lazima)
+        sw_boundary_long: Sanduku la kufunga la SW, longitudo (si lazima)
+        ne_boundary_lat: Sanduku la kufunga la NE, latitudo (si lazima)
+        ne_boundary_long: Sanduku la kufunga la NE, longitudo (si lazima)
+        background_img: Picha ya Mandharinyuma
+        sponsor_logos: Nembo za wafadhili
+        mapbox_style_url: URL ya Mtindo wa Mapbox
+        mapbox_access_token: Tokeni ya ufikiaji ya kisanduku cha ramani inayohusishwa na mtindo
+        mapbox_3d: Washa mwonekano wa 3D kwa ramani ya mtandaoni
+        zoom: Kiwango cha kukuza
+        pitch: Kiwango cha lami
+        bearing: Digrii ya ulaini
+        display_resource: "Mandhari ya Terrastories: %{community_name}"
+      user:
+        id: Id
+        email: Barua pepe
+        role: Jukumu
+  administrate:
+    actions:
+      confirm: Una uhakika?
+      destroy: Futa
+      edit: Hariri
+      edit_resource: Hariri %{name}
+      show_resource: Onyesha %{name}
+      new_resource: Mpya %{name}
+      back: Rudi
+    communities: Jumuiya
+    community: Jumuiya
+    controller:
+      create:
+        success: "%{resource} iliundwa kwa ufanisi."
+      destroy:
+        success: "%{resource} iliharibiwa kwa mafanikio."
+      update:
+        success: "%{resource} imesasishwa kwa ufanisi."
+    curriculum: Mtaala
+    curriculums: Mtaala
+    curriculum_story: Hadithi ya Mtaala
+    curriculum_stories: Hadithi ya Mtaala
+    fields:
+      has_many:
+        more: Matokeo %{count} kwa jumla ya %{total_count}
+        none: Hakuna
+      nested_has_many:
+        add: Ongeza
+        remove: Ondoa
+    file_to_update: Faili ya kusasisha
+    form:
+      error: kosa
+      errors: "%{pluralized_errors} hii imepigwa marufuku %{resource_name} kutokana na kuhifadhiwa:"
+    import_button: Ingiza %{resource}
+    places: Maeneo
+    place: Eneo
+    search:
+      clear: Futa utafutaji
+      label: "Tafuta %{resource}"
+      results: "matokeo"
+    speakers: Wazungumzaji
+    speaker: Mzungumzaji
+    stories: Hadithi
+    story: Hadithi
+    theme: Mandhari
+    themes: Mandhari
+    users: Watumiaji
+    user: Mtumiaji
+    media_link: Kiungo cha Media
+    media_links: Viungo cha Media
+    table_columns:
+      user:
+        id: Id
+        email: Barua pepe
+        role: Jukumu
+      speaker:
+        id: Id
+        photo: Picha
+        name: Jina
+        birthdate: Tarehe ya kuzaliwa
+        birthplace: Pahali pa kuzaliwa
+        speaker_community: Jumuiya ya mzungumzaji
+      story:
+        id: Id
+        title: Kichwa
+        desc: Maelezo
+        language: Lugha
+        speakers: Wazungumzaji
+        interview_location: Mahali pa mahojiano
+        interviewer: Mhojaji
+        date_interviewed: Tarehe ya mahojiano
+        places: Maeneo
+        permission_level: Kiwango cha ruhusa
+      place:
+        id: Id
+        name: Jina
+        description: Maelezo
+        type_of_place: Aina ya mahali
+        region: Eneo
+        long: Longitudo
+        lat: Latitudo
+        stories: Hadithi
+        photo: Picha
+        name_audio: Sauti ya Jina la mahali

--- a/rails/config/locales/sw/dashboard.sw.yml
+++ b/rails/config/locales/sw/dashboard.sw.yml
@@ -1,0 +1,53 @@
+en:
+  profile: Profile
+  interviewer: Interviewer
+  import: Import
+  map:
+    center: Map Center
+    bounds: Map Bounds
+    bounds_description: The boundaries of the map determine the extent of where you can scroll on the map. Unrestricted, the map will be infinitely scrollable.
+    sw_corner: Southwest Corner
+    ne_corner: Northeast Corner
+    unrestricted_bounds: Allow unrestricted bounds
+    online: Online Map Configuration
+    settings: Map Settings
+    settings_description: Customize your community's map settings.
+    projection:
+      mercator: Mercator
+      albers: Albers
+      equalEarth: Equal Earth
+      equirectangular: Equirectangular
+      lambertConformalConic: Lambert Comformal Conic
+      naturalEarth: Natural Earth
+      winkelTripel: Winkel Tripel
+  dashboard:
+    back_to_app: Back to App
+    community_settings: Community Settings
+    headings:
+      new_resource: New %{name}
+    actions:
+      confirm: Are you sure?
+      destroy: Delete
+      edit: Edit
+      new: New
+      back: Back
+      show_resource: Show %{name}
+    theme:
+      welcome_screen: Welcome Screen
+      background_img: Customize the background image on the landing page of your community.
+      sponsor_logos: Display logos on your community page. This could be your organization's logo, or that of a project sponsor. Multiple logos can be added.
+  search:
+    clear: Clear search
+    label: Search
+    heading: Search Results
+    results: results
+  filter:
+    all: All
+    any: Any
+    label: Filter
+    clear: Clear Filters
+  list:
+    prev: Prev
+    next: Next
+    no_results: There are no %{resources} available.
+    no_nested_results: This %{resource} has no %{resources}.

--- a/rails/config/locales/sw/dashboard.sw.yml
+++ b/rails/config/locales/sw/dashboard.sw.yml
@@ -1,17 +1,17 @@
-en:
-  profile: Profile
-  interviewer: Interviewer
-  import: Import
+sw:
+  profile: Wasifu
+  interviewer: Mhojaji
+  import: Ingiza
   map:
-    center: Map Center
-    bounds: Map Bounds
-    bounds_description: The boundaries of the map determine the extent of where you can scroll on the map. Unrestricted, the map will be infinitely scrollable.
-    sw_corner: Southwest Corner
-    ne_corner: Northeast Corner
-    unrestricted_bounds: Allow unrestricted bounds
-    online: Online Map Configuration
-    settings: Map Settings
-    settings_description: Customize your community's map settings.
+    center: Kituo cha Ramani
+    bounds: Mipaka ya Ramani
+    bounds_description: Mipaka ya ramani huamua kiwango ambacho unaweza kusogeza kwenye ramani. Bila vikwazo, ramani itakuwa inayoweza kusogezwa kabisa.
+    sw_corner: Kona ya Kusini Magharibi
+    ne_corner: Kona ya Kaskazini Mashariki
+    unrestricted_bounds: Ruhusu mipaka isiyo na kikomo
+    online: Umbo la Ramani ya Mtandaoni
+    settings: Mipangilio ya Ramani
+    settings_description: Geuza mipangilio ya ramani ya jumuiya yako kukufaa.
     projection:
       mercator: Mercator
       albers: Albers
@@ -21,33 +21,33 @@ en:
       naturalEarth: Natural Earth
       winkelTripel: Winkel Tripel
   dashboard:
-    back_to_app: Back to App
-    community_settings: Community Settings
+    back_to_app: Rudi kwenye Programu
+    community_settings: Mipangilio ya Jumuiya
     headings:
       new_resource: New %{name}
     actions:
-      confirm: Are you sure?
-      destroy: Delete
-      edit: Edit
-      new: New
-      back: Back
+      confirm: Una uhakika?
+      destroy: Futa
+      edit: Hariri
+      new: Mpya
+      back: Rudi
       show_resource: Show %{name}
     theme:
-      welcome_screen: Welcome Screen
-      background_img: Customize the background image on the landing page of your community.
-      sponsor_logos: Display logos on your community page. This could be your organization's logo, or that of a project sponsor. Multiple logos can be added.
+      welcome_screen: Skrini ya Kukaribisha
+      background_img: Geuza kukufaa picha ya usuli kwenye ukurasa wa kutua wa jumuiya yako.
+      sponsor_logos: Onyesha nembo kwenye ukurasa wako wa jumuiya. Hii inaweza kuwa nembo ya shirika lako au ya mfadhili wa mradi. Nembo nyingi zinaweza kuongezwa.
   search:
-    clear: Clear search
-    label: Search
-    heading: Search Results
-    results: results
+    clear: Futa utafutaji
+    label: Tafuta
+    heading: Matokeo ya Utafutaji
+    results: matokeo
   filter:
-    all: All
-    any: Any
-    label: Filter
-    clear: Clear Filters
+    all: Zote
+    any: Yoyote
+    label: Chuja
+    clear: Futa chujio
   list:
-    prev: Prev
-    next: Next
-    no_results: There are no %{resources} available.
+    prev: Iliyotangulia
+    next: Inayofuata
+    no_results: Hakuna %{resources} zinazopatikana.
     no_nested_results: This %{resource} has no %{resources}.

--- a/rails/config/locales/sw/devise.sw.yml
+++ b/rails/config/locales/sw/devise.sw.yml
@@ -1,0 +1,64 @@
+# Additional translations at https://github.com/plataformatec/devise/wiki/I18n
+
+en:
+  devise:
+    confirmations:
+      confirmed: "Your email address has been successfully confirmed."
+      send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
+    failure:
+      already_authenticated: "You are already signed in."
+      inactive: "Your account is not activated yet."
+      invalid: "Invalid %{authentication_keys} or password."
+      locked: "Your account is locked."
+      last_attempt: "You have one more attempt before your account is locked."
+      not_found_in_database: "Invalid %{authentication_keys} or password."
+      timeout: "Your session expired. Please sign in again to continue."
+      unauthenticated: "Please sign in with a community account."
+      unconfirmed: "You have to confirm your email address before continuing."
+    mailer:
+      confirmation_instructions:
+        subject: "Confirmation instructions"
+      reset_password_instructions:
+        subject: "Reset password instructions"
+      unlock_instructions:
+        subject: "Unlock instructions"
+      email_changed:
+        subject: "Email Changed"
+      password_change:
+        subject: "Password Changed"
+    omniauth_callbacks:
+      failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
+      success: "Successfully authenticated from %{kind} account."
+    passwords:
+      no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
+      send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
+      updated: "Your password has been changed successfully. You are now signed in."
+      updated_not_active: "Your password has been changed successfully."
+    registrations:
+      destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
+      signed_up: "Welcome! You have signed up successfully."
+      signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
+      signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
+      signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please follow the link to activate your account."
+      update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirm link to confirm your new email address."
+      updated: "Your account has been updated successfully."
+    sessions:
+      signed_in: "Signed in successfully."
+      signed_out: "Signed out successfully."
+      already_signed_out: "Signed out successfully."
+    unlocks:
+      send_instructions: "You will receive an email with instructions for how to unlock your account in a few minutes."
+      send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes."
+      unlocked: "Your account has been unlocked successfully. Please sign in to continue."
+  errors:
+    messages:
+      already_confirmed: "was already confirmed, please try signing in"
+      confirmation_period_expired: "needs to be confirmed within %{period}, please request a new one"
+      expired: "has expired, please request a new one"
+      not_found: "not found"
+      not_locked: "was not locked"
+      not_saved:
+        one: "1 error prohibited this %{resource} from being saved:"
+        other: "%{count} errors prohibited this %{resource} from being saved:"

--- a/rails/config/locales/sw/devise.sw.yml
+++ b/rails/config/locales/sw/devise.sw.yml
@@ -1,64 +1,64 @@
 # Additional translations at https://github.com/plataformatec/devise/wiki/I18n
 
-en:
+sw:
   devise:
     confirmations:
-      confirmed: "Your email address has been successfully confirmed."
-      send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."
-      send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
+      confirmed: "Barua pepe yako imethibitishwa."
+      send_instructions: "Utapokea barua pepe yenye maagizo ya jinsi ya kuthibitisha anwani yako ya barua pepe baada ya dakika chache."
+      send_paranoid_instructions: "Ikiwa anwani yako ya barua pepe iko kwenye hifadhidata yetu, utapokea barua pepe yenye maagizo ya jinsi ya kuthibitisha anwani yako ya barua pepe baada ya dakika chache."
     failure:
-      already_authenticated: "You are already signed in."
-      inactive: "Your account is not activated yet."
+      already_authenticated: "Tayari umeingia."
+      inactive: "Akaunti yako bado haijaamilishwa."
       invalid: "Invalid %{authentication_keys} or password."
-      locked: "Your account is locked."
-      last_attempt: "You have one more attempt before your account is locked."
+      locked: "Akaunti yako imefungwa."
+      last_attempt: "Una jaribio moja zaidi kabla ya akaunti yako kufungwa."
       not_found_in_database: "Invalid %{authentication_keys} or password."
-      timeout: "Your session expired. Please sign in again to continue."
-      unauthenticated: "Please sign in with a community account."
-      unconfirmed: "You have to confirm your email address before continuing."
+      timeout: "Kipindi chako kimekwisha. Tafadhali ingia tena ili kuendelea."
+      unauthenticated: "Tafadhali ingia kwa akaunti ya jumuiya."
+      unconfirmed: "Lazima uthibitishe anwani yako ya barua pepe kabla ya kuendelea."
     mailer:
       confirmation_instructions:
-        subject: "Confirmation instructions"
+        subject: "Maagizo ya uthibitisho"
       reset_password_instructions:
-        subject: "Reset password instructions"
+        subject: "Weka upya maagizo ya nenosiri"
       unlock_instructions:
-        subject: "Unlock instructions"
+        subject: "Fungua maagizo"
       email_changed:
-        subject: "Email Changed"
+        subject: "Barua pepe Imebadilishwa"
       password_change:
-        subject: "Password Changed"
+        subject: "Nenosiri Limebadilishwa"
     omniauth_callbacks:
-      failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
-      success: "Successfully authenticated from %{kind} account."
+      failure: 'Haikuweza kukuthibitisha kutoka kwa %{kind} kwa sababu "%{reason}".'
+      success: "Imethibitishwa kutoka kwa akaunti %{kind}."
     passwords:
-      no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
-      send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."
-      send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
-      updated: "Your password has been changed successfully. You are now signed in."
-      updated_not_active: "Your password has been changed successfully."
+      no_token: "Huwezi kufikia ukurasa huu bila kuja kutoka kwa barua pepe ya kuweka upya nenosiri. Ikiwa umetoka kwa barua pepe ya kuweka upya nenosiri, tafadhali hakikisha kuwa umetumia URL kamili iliyotolewa."
+      send_instructions: "Utapokea barua pepe yenye maagizo ya jinsi ya kuweka upya nenosiri lako baada ya dakika chache."
+      send_paranoid_instructions: "Ikiwa anwani yako ya barua pepe ipo katika hifadhidata yetu, utapokea kiungo cha kurejesha nenosiri kwenye anwani yako ya barua pepe baada ya dakika chache."
+      updated: "Nenosiri lako limebadilishwa. Sasa umeingia."
+      updated_not_active: "Nenosiri lako limebadilishwa."
     registrations:
-      destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
-      signed_up: "Welcome! You have signed up successfully."
-      signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
-      signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
-      signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please follow the link to activate your account."
-      update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirm link to confirm your new email address."
-      updated: "Your account has been updated successfully."
+      destroyed: "Kwaheri! Akaunti yako imeghairiwa. Tunatumai kukuona tena hivi karibuni."
+      signed_up: "Karibu! Umefaulu kujiandikisha."
+      signed_up_but_inactive: "Umefaulu kujiandikisha. Hata hivyo, hatukuweza kukuingiza kwa sababu akaunti yako bado haijaamilishwa."
+      signed_up_but_locked: "Umefaulu kujiandikisha. Hata hivyo, hatukuweza kukuingiza kwa sababu akaunti yako imefungwa."
+      signed_up_but_unconfirmed: "Ujumbe ulio na kiungo cha uthibitishaji umetumwa kwa anwani yako ya barua pepe. Tafadhali fuata kiungo ili kuwezesha akaunti yako."
+      update_needs_confirmation: "Ulisasisha akaunti yako kwa mafanikio, lakini tunahitaji kuthibitisha anwani yako mpya ya barua pepe. Tafadhali angalia barua pepe yako na ufuate kiungo cha uthibitishaji ili kuthibitisha anwani yako mpya ya barua pepe."
+      updated: "Akaunti yako imesasishwa."
     sessions:
-      signed_in: "Signed in successfully."
-      signed_out: "Signed out successfully."
-      already_signed_out: "Signed out successfully."
+      signed_in: "Umeingia katika akaunti."
+      signed_out: "Umeondoka kwenye akaunti."
+      already_signed_out: "Umeondoka kwenye akaunti."
     unlocks:
-      send_instructions: "You will receive an email with instructions for how to unlock your account in a few minutes."
-      send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes."
-      unlocked: "Your account has been unlocked successfully. Please sign in to continue."
+      send_instructions: "Utapokea barua pepe yenye maagizo ya jinsi ya kufungua akaunti yako baada ya dakika chache."
+      send_paranoid_instructions: "Ikiwa akaunti yako ipo, utapokea barua pepe yenye maelekezo ya jinsi ya kuifungua baada ya dakika chache."
+      unlocked: "Akaunti yako imefunguliwa. Tafadhali ingia ili kuendelea."
   errors:
     messages:
-      already_confirmed: "was already confirmed, please try signing in"
-      confirmation_period_expired: "needs to be confirmed within %{period}, please request a new one"
-      expired: "has expired, please request a new one"
-      not_found: "not found"
-      not_locked: "was not locked"
+      already_confirmed: "tayari imethibitishwa, tafadhali jaribu kuingia"
+      confirmation_period_expired: "inahitaji kuthibitishwa ndani ya %{period}, tafadhali omba mpya"
+      expired: "muda wake umeisha, tafadhali omba mpya"
+      not_found: "haipatikani"
+      not_locked: "haikuwa imefungwa"
       not_saved:
-        one: "1 error prohibited this %{resource} from being saved:"
-        other: "%{count} errors prohibited this %{resource} from being saved:"
+        one: "Hitilafu 1 ilikataza %{resource} hii kuhifadhiwa:"
+        other: "Hitilafu %{count} zilikataza %{resource} hii kuhifadhiwa:"

--- a/rails/config/locales/sw/models.sw.yml
+++ b/rails/config/locales/sw/models.sw.yml
@@ -1,0 +1,114 @@
+en:
+  errors:
+    messages:
+      map_bounds: All four bounding box values must be set, or left blank
+      invalid_latitude: value should be between -90 and 90
+      invalid_longitude: value should be between -180 and 180
+      invalid_zoom_level: value should be between 0 and 22
+      invalid_pitch: value should be 0 and 85
+      invalid_bearing: value should be between -180 and 180
+      invalid_username_format: cannot contain spaces
+  helpers:
+    label:
+      place:
+        one: Place
+      speaker:
+        one: Speaker
+      visibility: Visibility
+  activerecord:
+    errors:
+      models:
+        place:
+          attributes:
+            name_audio:
+              content_type: content type is not in list
+            photo:
+              content_type: content type is not in list
+        story:
+          attributes:
+            place_ids:
+              blank: Your story must have a Place
+            speaker_ids:
+              blank: Your story must have at least one Speaker
+        theme:
+          attributes:
+            background_img:
+              content_type: content type is not in list
+            mapbox_access_token:
+              blank: is required when the Mapbox style URL is set.
+            mapbox_style_url:
+              blank: is required when the Mapbox access token is set.
+    # Used to auto-translate submit buttons
+    models:
+      community: Community
+      curriculum: Curriculum
+      user: User
+      place: Place
+      speaker: Speaker
+      story: Story
+      theme: Theme
+      media_link: Media Link
+    # Used for model-based form labels and other attribute displays
+    attributes:
+      place:
+        name: Name
+        name_audio: Placename Audio
+        description: Description
+        type_of_place: Type of Place
+        region: Region
+        long: Longitude
+        lat: Latitude
+        story_ids: Stories
+        photo: Photo
+      speaker:
+        name: Name
+        story_ids: Stories
+        photo: Photo
+        speaker_community: Speaker's Community
+        birthdate: Date of Birth
+        birthplace_id: Born Where
+      story:
+        title: Title
+        desc: Description
+        language: Language
+        topic: Topic
+        date_interviewed: Date interviewed
+        media: Media
+        speaker_ids: Speakers
+        place_ids: Places
+        interview_location_id: Interview location
+        interviewer_id: Interviewer
+        permission_level: Permission level
+      story/permission_level:
+        anonymous: Anonymous
+        user_only: Member
+        editor_only: Editor
+      theme:
+        background_img: Background image
+        sponsor_logos: Sponsor logos
+        mapbox_style_url: Mapbox style URL
+        mapbox_access_token: Mapbox access token associated with the style
+        mapbox_3d: Activate 3D Terrain view for online map
+        center_lat: Latitude
+        center_long: Longitude
+        sw_boundary_lat: Min Latitude
+        sw_boundary_long: Min Longitude
+        ne_boundary_lat: Max Latitude
+        ne_boundary_long: Max Longitude
+        zoom: Zoom level
+        pitch: Pitch degree
+        bearing: Bearing degrees
+        map_projection: Set projection for map
+      user:
+        login: Username or Email
+        name: Display Name
+        username: Username
+        email: Email
+        role: Role
+        password: Password
+        photo: Photo
+      user/role:
+        admin: Administrator
+        editor: Editor
+        member: Member
+        viewer: Viewer

--- a/rails/config/locales/sw/models.sw.yml
+++ b/rails/config/locales/sw/models.sw.yml
@@ -1,94 +1,94 @@
-en:
+sw:
   errors:
     messages:
-      map_bounds: All four bounding box values must be set, or left blank
-      invalid_latitude: value should be between -90 and 90
-      invalid_longitude: value should be between -180 and 180
-      invalid_zoom_level: value should be between 0 and 22
-      invalid_pitch: value should be 0 and 85
-      invalid_bearing: value should be between -180 and 180
-      invalid_username_format: cannot contain spaces
+      map_bounds: Thamani zote nne za kisanduku cha kufunga lazima ziwekwe au ziachwe wazi
+      invalid_latitude: thamani inapaswa kuwa kati ya -90 na 90
+      invalid_longitude: thamani inapaswa kuwa kati ya -180 na 180
+      invalid_zoom_level: thamani inapaswa kuwa kati ya 0 na 22
+      invalid_pitch: thamani inapaswa kuwa 0 na 85
+      invalid_bearing: thamani inapaswa kuwa kati ya -180 na 180
+      invalid_username_format: haiwezi kuwa na nafasi
   helpers:
     label:
       place:
-        one: Place
+        one: Eneo
       speaker:
-        one: Speaker
-      visibility: Visibility
+        one: Mzungumzaji
+      visibility: Mwonekano
   activerecord:
     errors:
       models:
         place:
           attributes:
             name_audio:
-              content_type: content type is not in list
+              content_type: aina ya maudhui haipo kwenye orodha
             photo:
-              content_type: content type is not in list
+              content_type: aina ya maudhui haipo kwenye orodha
         story:
           attributes:
             place_ids:
-              blank: Your story must have a Place
+              blank: Hadithi yako lazima iwe na Eneo
             speaker_ids:
-              blank: Your story must have at least one Speaker
+              blank: Hadithi yako lazima iwe na angalau Mzungumzaji mmoja
         theme:
           attributes:
             background_img:
-              content_type: content type is not in list
+              content_type: aina ya maudhui haipo kwenye orodha
             mapbox_access_token:
-              blank: is required when the Mapbox style URL is set.
+              blank: inahitajika wakati URL ya mtindo wa Mapbox imewekwa.
             mapbox_style_url:
-              blank: is required when the Mapbox access token is set.
+              blank: inahitajika wakati tokeni ya ufikiaji ya Mapbox imewekwa.
     # Used to auto-translate submit buttons
     models:
-      community: Community
-      curriculum: Curriculum
-      user: User
-      place: Place
-      speaker: Speaker
-      story: Story
-      theme: Theme
-      media_link: Media Link
+      community: Jumuiya
+      curriculum: Mtaala
+      user: Mtumiaji
+      place: Eneo
+      speaker: Mzungumzaji
+      story: Hadithi
+      theme: Mandhari
+      media_link: Kiungo cha Media
     # Used for model-based form labels and other attribute displays
     attributes:
       place:
-        name: Name
-        name_audio: Placename Audio
-        description: Description
-        type_of_place: Type of Place
-        region: Region
+        name: Jina
+        name_audio: Sauti ya Jina la Eneo
+        description: Maelezo
+        type_of_place: Aina ya Eneo
+        region: Eneo
         long: Longitude
         lat: Latitude
-        story_ids: Stories
-        photo: Photo
+        story_ids: Hadithi
+        photo: Picha
       speaker:
-        name: Name
-        story_ids: Stories
-        photo: Photo
-        speaker_community: Speaker's Community
-        birthdate: Date of Birth
-        birthplace_id: Born Where
+        name: Jina
+        story_ids: Hadithi
+        photo: Picha
+        speaker_community: Jumuiya ya Mzungumzaji
+        birthdate: Tarehe ya kuzaliwa
+        birthplace_id: Kuzaliwa wapi
       story:
-        title: Title
-        desc: Description
-        language: Language
-        topic: Topic
-        date_interviewed: Date interviewed
+        title: Kichwa
+        desc: Maelezo
+        language: Lugha
+        topic: Mada
+        date_interviewed: Tarehe ya kuhojiwa
         media: Media
-        speaker_ids: Speakers
-        place_ids: Places
-        interview_location_id: Interview location
-        interviewer_id: Interviewer
-        permission_level: Permission level
+        speaker_ids: Wanazungumzaji
+        place_ids: Maeneo
+        interview_location_id: Mahali pa mahojiano
+        interviewer_id: Mhojaji
+        permission_level: Kiwango cha ruhusa
       story/permission_level:
-        anonymous: Anonymous
-        user_only: Member
-        editor_only: Editor
+        anonymous: Asiyejulikana
+        user_only: Mwanachama
+        editor_only: Mhariri
       theme:
-        background_img: Background image
-        sponsor_logos: Sponsor logos
-        mapbox_style_url: Mapbox style URL
-        mapbox_access_token: Mapbox access token associated with the style
-        mapbox_3d: Activate 3D Terrain view for online map
+        background_img: Picha ya usuli
+        sponsor_logos: Nembo za wafadhili
+        mapbox_style_url: URL ya mtindo wa kisanduku cha ramani
+        mapbox_access_token: Ishara ya ufikiaji ya kisanduku cha ramani inayohusishwa na mtindo
+        mapbox_3d: Wezesha mwonekano wa 3D Terrain kwa ramani ya mtandaoni
         center_lat: Latitude
         center_long: Longitude
         sw_boundary_lat: Min Latitude
@@ -100,15 +100,15 @@ en:
         bearing: Bearing degrees
         map_projection: Set projection for map
       user:
-        login: Username or Email
-        name: Display Name
-        username: Username
-        email: Email
-        role: Role
-        password: Password
-        photo: Photo
+        login: Jina la mtumiaji au Barua pepe
+        name: Jina la Kuonyesha
+        username: Jina la mtumiaji
+        email: Barua pepe
+        role: Jukumu
+        password: Nenosiri
+        photo: Picha
       user/role:
         admin: Administrator
-        editor: Editor
-        member: Member
-        viewer: Viewer
+        editor: Mhariri
+        member: Mwanachama
+        viewer: Mtazamaji

--- a/rails/config/locales/sw/sw.yml
+++ b/rails/config/locales/sw/sw.yml
@@ -1,0 +1,55 @@
+en:
+  community: Community
+  communities: Communities
+  media_link: Media Link
+  media_links: Media Links
+  places: Places
+  place: Place
+  speakers: Speakers
+  speaker: Speaker
+  stories: Stories
+  story: Story
+  theme: Theme
+  users: Users
+  user: User
+
+  # Front End Translations
+  admin_page: "Admin Page"
+  alphabetical: A-Z
+  back_to_map: "Back to Map"
+  back_to_welcome: "Back to Welcome Page"
+  built_with_love: Built with ❤️ by
+  close: Close
+  community_search:
+    title: "Search for a Community to Explore"
+    coming_soon: "This feature is coming soon. For now, please request an invite to a specific community."
+  default: default
+  enter: "Enter Site"
+  filter_stories: "Filter stories"
+  forgot_password: "Forgot your password?"
+  hello: Hello
+  introduction: Introduction
+  intro:
+    explanation: "Terrastories are audiovisual recordings of place-based storytelling. This offline-compatible application enables local communities to locate and map their own oral storytelling traditions about places of significant meaning or value to them."
+    question: "What's a terrastory?"
+  language: Language
+  login: Login
+  logout: Logout
+  most_recent: "Most recent"
+  no_media: No Media Available
+  password: Password
+  place_name: "Place name pronunciation"
+  place_type: "Type of place"
+  region: Region
+  remember_me: "Remember me"
+  reversed_alphabetical: Z-A
+  select_category: "Select category"
+  select_option: "Select option"
+  selected_language: "selected"
+  sign_up: "Sign up"
+  sort_stories: "Sort stories"
+  speaker: Speaker
+  topic: Topic
+  video_unsupported: Sorry, your browser doesn't support embedded videos.
+  welcome: Welcome
+  welcome_back: "Welcome back"

--- a/rails/config/locales/sw/sw.yml
+++ b/rails/config/locales/sw/sw.yml
@@ -1,55 +1,55 @@
-en:
-  community: Community
-  communities: Communities
-  media_link: Media Link
-  media_links: Media Links
-  places: Places
-  place: Place
-  speakers: Speakers
-  speaker: Speaker
-  stories: Stories
-  story: Story
-  theme: Theme
-  users: Users
-  user: User
+sw:
+  community: Jumuiya
+  communities: Jumuiya
+  media_link: Kiungo cha Media
+  media_links: Viungo cha Media
+  places: Maeneo
+  place: Eneo
+  speakers: Wazungumzaji
+  speaker: Mzungumzaji
+  stories: Hadithi
+  story: Hadithi
+  theme: Mandhari
+  users: Watumiaji
+  user: Mtumiaji
 
   # Front End Translations
-  admin_page: "Admin Page"
+  admin_page: "Ukurasa wa Msimamizi"
   alphabetical: A-Z
-  back_to_map: "Back to Map"
-  back_to_welcome: "Back to Welcome Page"
-  built_with_love: Built with ❤️ by
-  close: Close
+  back_to_map: "Rudi kwenye Ramani"
+  back_to_welcome: "Rudi kwenye Ukurasa wa Karibu"
+  built_with_love: Imeundwa kwa ❤️ na
+  close: Funga
   community_search:
-    title: "Search for a Community to Explore"
-    coming_soon: "This feature is coming soon. For now, please request an invite to a specific community."
-  default: default
-  enter: "Enter Site"
-  filter_stories: "Filter stories"
-  forgot_password: "Forgot your password?"
+    title: "Tafuta Jumuiya ya Tafiti"
+    coming_soon: "Kipengele hiki kinakuja hivi karibuni. Kwa sasa, tafadhali omba mwaliko kwa jumuiya mahususi."
+  default: chaguo-msingi
+  enter: "Ingiza Tovuti"
+  filter_stories: "Chuja hadithi"
+  forgot_password: "Umesahau nenosiri yako?"
   hello: Hello
-  introduction: Introduction
+  introduction: Utangulizi
   intro:
-    explanation: "Terrastories are audiovisual recordings of place-based storytelling. This offline-compatible application enables local communities to locate and map their own oral storytelling traditions about places of significant meaning or value to them."
-    question: "What's a terrastory?"
-  language: Language
-  login: Login
-  logout: Logout
-  most_recent: "Most recent"
-  no_media: No Media Available
-  password: Password
-  place_name: "Place name pronunciation"
-  place_type: "Type of place"
-  region: Region
-  remember_me: "Remember me"
+    explanation: "Terrastories ni rekodi za sauti na taswira za usimulizi wa hadithi unaotegemea mahali. Programu hii inayotumika nje ya mtandao huwezesha jamii za wenyeji kupata na kuweka ramani mila zao za kusimulia hadithi kuhusu maeneo yenye maana au thamani kubwa kwao."
+    question: "Terrastory ni nini?"
+  language: Lugha
+  login: Ingia
+  logout: Ondoka
+  most_recent: "Hivi karibuni"
+  no_media: Hakuna Media ya Kusimulia Hadithi
+  password: Nenosiri
+  place_name: "Matamshi ya jina la mahali"
+  place_type: "Aina ya eneo"
+  region: Eneo
+  remember_me: "Nikumbuke"
   reversed_alphabetical: Z-A
-  select_category: "Select category"
-  select_option: "Select option"
-  selected_language: "selected"
-  sign_up: "Sign up"
-  sort_stories: "Sort stories"
-  speaker: Speaker
-  topic: Topic
-  video_unsupported: Sorry, your browser doesn't support embedded videos.
-  welcome: Welcome
-  welcome_back: "Welcome back"
+  select_category: "Chagua kategoria"
+  select_option: "Chagua chaguo"
+  selected_language: "iliyochaguliwa"
+  sign_up: "Jisajili"
+  sort_stories: "Panga hadithi"
+  speaker: Mzungumzaji  
+  topic: Mada
+  video_unsupported: Samahani, kivinjari chako hakitumii video zilizopachikwa.
+  welcome: Karibu   
+  welcome_back: "Karibu tena"


### PR DESCRIPTION
Added a Swahili translation of the terrastories per the directions given in issue no: [826](https://github.com/Terrastories/terrastories/issues/826). 

To begin with, I translated the `adminstarte.sw.yml` file, currently working on the other files. I would like to be a long-term contributor fo the project.