### PR TITLE
Administrate Refactor Part 2: Switch to new dashboard!

### DIFF
--- a/rails/app/javascript/components/Card.jsx
+++ b/rails/app/javascript/components/Card.jsx
@@ -47,7 +47,7 @@ class Card extends Component {
       return (
         <ul>
           <li>{I18n.t("hello")} {this.props.user.display_name} (<a href={`/${I18n.currentLocale()}`}>{I18n.t("back_to_welcome")}</a>)</li>
-          <li><a href={`/admin?locale=${I18n.currentLocale()}`}>{I18n.t("admin_page")}</a></li>
+          <li><a href={`/${I18n.currentLocale()}/member`}>{I18n.t("admin_page")}</a></li>
         </ul>
       );
     } else if (this.props.user) {

--- a/rails/app/views/welcome/index.html.erb
+++ b/rails/app/views/welcome/index.html.erb
@@ -14,9 +14,9 @@
     <div class="welcome-card-user">
       <% if user_signed_in? %>
         <% if current_user.admin? || current_user.editor? %>
-          <%= link_to t("admin_page"), admin_root_path, :class => 'navbar-link' %> |
+          <%= link_to t("admin_page"), member_root_path, :class => 'navbar-link' %> |
         <% else %>
-          <%= link_to "Community", admin_root_path, :class => 'navbar-link' %> |
+          <%= link_to t("community"), member_root_path, :class => 'navbar-link' %> |
         <% end %>
         <%= link_to t("logout"), destroy_user_session_path, method: :delete, :class => 'navbar-link'  %>
       <% else %>


### PR DESCRIPTION
In part 1 of the refactor, we added a new member and super-admin dashboard. This was added alongside the original Administrate admin CMS interface.

In Part 2, we now use the new dashboard by switching over the links. Administate cms will be still be accessible by accessing /admin instead of /member if necessary.