### PR TITLE
(#865) Create sort element to allow super-admin to sort communities by last updated, date created, and alphabetical

### DIFF
--- a/rails/app/controllers/dashboard/communities_controller.rb
+++ b/rails/app/controllers/dashboard/communities_controller.rb
@@ -71,7 +71,9 @@ module Dashboard
       params.permit(
         :limit,
         :offset,
-        :name
+        :name,
+        :sort_by,
+        :sort_dir
       )
     end
 

--- a/rails/app/pages/communities_page.rb
+++ b/rails/app/pages/communities_page.rb
@@ -2,10 +2,18 @@ class CommunitiesPage < Page
   def initialize(meta = {})
     @meta = meta
 
+    unless %w(name created_at updated_at).include? @meta[:sort_by]
+      @meta[:sort_by] = nil
+    end
+
+    unless %w(asc desc).include? @meta[:sort_dir]
+      @meta[:sort_dir] = nil
+    end
+
     @meta[:limit] ||= 20
     @meta[:offset] ||= 0
-    @meta[:sort_by] ||= "name"
-    @meta[:sort_dir] ||= "asc"
+    @meta[:sort_by] ||= "updated_at"
+    @meta[:sort_dir] ||= "desc"
   end
 
   def relation

--- a/rails/app/views/dashboard/communities/index.html.erb
+++ b/rails/app/views/dashboard/communities/index.html.erb
@@ -14,6 +14,15 @@
     </div>
     <%= f.submit t("search.label"), name: nil %>
   <% end %>
+
+  <div>
+    <%= t("sort.label") %>
+    <%= link_to t("sort.updated_at"), communities_url(request.query_parameters.merge(sort_by: "updated_at", sort_dir: "desc")) %>
+    |
+    <%= link_to t("sort.created_at"), communities_url(request.query_parameters.merge(sort_by: "created_at", sort_dir: "desc")) %>
+    |
+    <%= link_to t("sort.name"), communities_url(request.query_parameters.merge(sort_by: "name", sort_dir: "asc")) %>
+  </div>
 <% end %>
 
 <div class="infinite-scroll">

--- a/rails/config/locales/am/dashboard.am.yml
+++ b/rails/config/locales/am/dashboard.am.yml
@@ -54,3 +54,8 @@ am:
     next: ቀጣይ
     no_results: የሚገኙ ምንም %{resources} የሉም።
     no_nested_results: ይህ %{resource} %{resources} የለውም።
+  sort:
+    label: የተደረደረው በ፡
+    name: ፊደላት
+    created_at: ቀን ተፈጠረ
+    updated_at: ቀን የዘመነ

--- a/rails/config/locales/en/dashboard.en.yml
+++ b/rails/config/locales/en/dashboard.en.yml
@@ -54,3 +54,8 @@ en:
     next: Next
     no_results: There are no %{resources} available.
     no_nested_results: This %{resource} has no %{resources}.
+  sort:
+    label: "Sort by:"
+    name: alphabetical
+    created_at: date created
+    updated_at: date last updated

--- a/rails/config/locales/es/dashboard.es.yml
+++ b/rails/config/locales/es/dashboard.es.yml
@@ -54,3 +54,8 @@ es:
     next: Sig
     no_results: No hay %{resources} disponibles.
     no_nested_results: Este %{resource} no tiene %{resources}.
+  sort:
+    label: "Ordenar por:"
+    name: alfabético
+    created_at: fecha de creación
+    updated_at: fecha de última actualización

--- a/rails/config/locales/ja/dashboard.ja.yml
+++ b/rails/config/locales/ja/dashboard.ja.yml
@@ -54,3 +54,8 @@ ja:
     next: Next
     no_results: There are no %{resources} available.
     no_nested_results: This %{resource} has no %{resources}.
+  sort:
+    label: "並び替え："
+    name: アルファベット順
+    created_at: 作成日
+    updated_at: 最終更新日

--- a/rails/config/locales/mat/dashboard.mat.yml
+++ b/rails/config/locales/mat/dashboard.mat.yml
@@ -54,3 +54,8 @@ mat:
     next: Volgende
     no_results: Er zijn geen %{resources} beschikbaar.
     no_nested_results: Deze %{resource} heeft geen %{resources}.
+  sort:
+    label: "Sorteer op:"
+    name: alfabetisch
+    created_at: datum gecreeërd
+    updated_at: datum laatst bijgewerkt

--- a/rails/config/locales/nl/dashboard.nl.yml
+++ b/rails/config/locales/nl/dashboard.nl.yml
@@ -54,3 +54,8 @@ nl:
     next: Volgende
     no_results: Er zijn geen %{resources} beschikbaar.
     no_nested_results: Deze %{resource} heeft geen %{resources}.
+  sort:
+    label: "Sorteer op:"
+    name: alfabetisch
+    created_at: datum gecreeërd
+    updated_at: datum laatst bijgewerkt

--- a/rails/config/locales/pt/dashboard.pt.yml
+++ b/rails/config/locales/pt/dashboard.pt.yml
@@ -54,3 +54,8 @@ pt:
     next: Prox
     no_results: Não há nenhum %{resources} disponível.
     no_nested_results: Este %{resource} não contém nenhum %{resources}.
+  sort:
+    label: "Ordenar por:"
+    name: alfabética
+    created_at: data da criação
+    updated_at: data da última atualização

--- a/rails/config/locales/sw/dashboard.sw.yml
+++ b/rails/config/locales/sw/dashboard.sw.yml
@@ -54,3 +54,8 @@ sw:
     next: Inayofuata
     no_results: Hakuna %{resources} zinazopatikana.
     no_nested_results: This %{resource} has no %{resources}.
+  sort:
+    label: "Panga kwa:"
+    name: kialfabeti
+    created_at: tarehe iliyoundwa
+    updated_at: tarehe ya sasisho la mwisho

--- a/rails/config/locales/zh/dashboard.zh.yml
+++ b/rails/config/locales/zh/dashboard.zh.yml
@@ -54,3 +54,8 @@ zh:
     next: 下一页
     no_results: 此%{resources}不可用。
     no_nested_results: 此%{resource}没有%{resources}。
+  sort:
+    label: 排序方式：
+    name: 按字母顺序
+    created_at: 创建日期
+    updated_at: 上次更新日期


### PR DESCRIPTION
Hey everyone! :)
First and foremost: super cool project, congratulations on the effort! :heart: 

I decided to leave a small contribution as detailed in issue #865 .

The sorting was implemented by allowing params `sort_by` and `sort_dir` in the controller. The sort buttons act as links which add the corresponding params to the index. I've also included some very rudimentary value validation in `communities_page.rb` - please let me know if there's a better way around this as I'm not fully aware of Rails best practices!

The default sort was also changed from `name` (alphabetical) to `updated_at` (date last updated).

Most translations (by Google Translate -- hopefully they're accurate!) were included. I did particularly have trouble finding a translator for the `mat` locale, so I left placeholder strings copied from `nl`. 

Here's how it turned out visually:
![Screenshot from 2022-10-29 01-59-27](https://user-images.githubusercontent.com/15658199/198814944-ea083050-c5b0-4cd8-81cd-8ed099c5abc3.png)

After selecting alphabetical sort:
![Screenshot from 2022-10-29 01-59-36](https://user-images.githubusercontent.com/15658199/198814952-a459ac4b-e23c-46bd-ab23-024c325b5581.png)
