### PR TITLE
Fix: locales pu.yml and hi.yml locale loading error

### DIFF
--- a/rails/config/locales/hi/hi.yml
+++ b/rails/config/locales/hi/hi.yml
@@ -13,7 +13,7 @@ hi:
   users: उपयोगकर्ताओं
   user: प्रयोक्ता
 
-  भाषाओं:
+  languages:
     am: अम्हारिक्
     en: अंग्रेज़ी
     es: स्पैनिश
@@ -25,7 +25,7 @@ hi:
     zh: चीनी
     hi: हिन्दी
     pu: पंजाबी
-    
+
   # Front End Translations
   admin_page: "व्यवस्थापक पृष्ठ"
   alphabetical: वर्णमाला क्रम (A-Z)
@@ -62,7 +62,7 @@ hi:
   sign_up: "साइन अप करें"
   sort_stories: "कहानियों को क्रमबद्ध करें"
   speaker: वक्ता
-  topic: विषय 
+  topic: विषय
   video_unsupported: क्षमा करें, आपका ब्राउज़र एम्बेड किए गए वीडियो का समर्थन नहीं करता है।
   welcome: स्वागत हे
   welcome_back: "फिर से स्वागत"

--- a/rails/config/locales/pu/pu.yml
+++ b/rails/config/locales/pu/pu.yml
@@ -13,7 +13,7 @@ pu:
   users: ਉਪਭੋਗਤਾ
   user: ਉਪਭੋਗਤਾ
 
-    ਭਾਸ਼ਾਵਾਂ::
+  languages:
     am: ਅਮਹਾਰਿਕ
     en: ਅੰਗਰੇਜ਼ੀ
     es: ਸਪੇਨੀ
@@ -27,13 +27,13 @@ pu:
     pu: ਪੰਜਾਬੀ
 
   # Front End Translations
-   admin_page: "ਪ੍ਰਬੰਧਕ ਪੰਨਾ"
-   alphabetical: A-Z
-   back_to_map: "ਨਕਸ਼ੇ 'ਤੇ ਵਾਪਸ"
-   back_to_welcome: "ਵਾਪਸ ਸੁਆਗਤ ਪੰਨੇ 'ਤੇ"
-   build_with_love: ❤️ ਦੁਆਰਾ ਬਣਾਇਆ ਗਿਆ
-   close: ਬੰਦ ਕਰੋ
-  ਭਾਈਚਾਰੇ_ਖੋਜ:
+  admin_page: "ਪ੍ਰਬੰਧਕ ਪੰਨਾ"
+  alphabetical: A-Z
+  back_to_map: "ਨਕਸ਼ੇ 'ਤੇ ਵਾਪਸ"
+  back_to_welcome: "ਵਾਪਸ ਸੁਆਗਤ ਪੰਨੇ 'ਤੇ"
+  build_with_love: ❤️ ਦੁਆਰਾ ਬਣਾਇਆ ਗਿਆ
+  close: ਬੰਦ ਕਰੋ
+  community_search:
     title: "ਪੜਚੋਲ ਕਰਨ ਲਈ ਇੱਕ ਭਾਈਚਾਰਾ ਖੋਜੋ"
     coming_soon: "ਇਹ ਵਿਸ਼ੇਸ਼ਤਾ ਜਲਦੀ ਹੀ ਆ ਰਹੀ ਹੈ। ਫਿਲਹਾਲ, ਕਿਰਪਾ ਕਰਕੇ ਕਿਸੇ ਖਾਸ ਭਾਈਚਾਰੇ ਨੂੰ ਸੱਦਾ ਦੇਣ ਦੀ ਬੇਨਤੀ ਕਰੋ।"
   default: ਡਿਫਾਲਟ


### PR DESCRIPTION
When starting Terrastories, locale mapping load failures occurred on pu.yml and hi.yml.

This PR fixes:
- Formatting issues in the yml files (extra spaces)
- Inadvertent translation of lookup keys (only values should be translated)