### PR TITLE
feat: Enable Feature Flagging

### DIFF
--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -55,6 +55,10 @@ gem 'plyr-rails'
 # Use ActiveStorage variant
 gem 'image_processing'
 
+# Use Flipper for feature flags
+gem 'flipper'
+gem 'flipper-active_record'
+
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 

--- a/rails/Gemfile.lock
+++ b/rails/Gemfile.lock
@@ -132,6 +132,10 @@ GEM
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
     ffi (1.15.5)
+    flipper (0.25.3)
+    flipper-active_record (0.25.3)
+      activerecord (>= 4.2, < 8)
+      flipper (~> 0.25.3)
     formatador (1.1.0)
     geocoder (1.7.5)
     globalid (1.0.0)
@@ -350,6 +354,8 @@ DEPENDENCIES
   devise
   devise-i18n
   factory_bot_rails
+  flipper
+  flipper-active_record
   geocoder
   guard-rspec
   i18n-js

--- a/rails/app/assets/stylesheets/cms/_badges.scss
+++ b/rails/app/assets/stylesheets/cms/_badges.scss
@@ -26,4 +26,36 @@
   &-blue {
     background-color: $blue;
   }
+
+  &__state {
+    display: inline-block;
+
+    &-on {
+      background-color: $green;
+    }
+
+    &-conditional {
+      background-color: $yellow;
+    }
+
+    &-off {
+      background-color: $red;
+    }
+
+    &-disabled {
+      background-color: $light-gray;
+    }
+
+    &-group {
+      background-color: $blue;
+    }
+
+    &-community {
+      background-color: $orange;
+    }
+
+    &-all {
+      background-color: $green;
+    }
+  }
 }

--- a/rails/app/assets/stylesheets/cms/_cards.scss
+++ b/rails/app/assets/stylesheets/cms/_cards.scss
@@ -41,6 +41,10 @@
     max-width: 150px;
   }
 
+  &--metrics {
+    max-width: 200px;
+  }
+
   &--center {
     align-items: center;
   }

--- a/rails/app/assets/stylesheets/cms/_columns.scss
+++ b/rails/app/assets/stylesheets/cms/_columns.scss
@@ -29,6 +29,17 @@
   margin-right: 0.5rem;
 }
 
+.columns-50-50 {
+  min-width: 50%;
+  row-gap: 10px;
+
+  > * {
+    width: 100%;
+  }
+  p {
+    padding-bottom: 1rem;
+  }
+}
 
 @media (min-width: "1180px") {
   .two-columns {

--- a/rails/app/assets/stylesheets/cms/_links.scss
+++ b/rails/app/assets/stylesheets/cms/_links.scss
@@ -81,6 +81,7 @@ nav > a,
 }
 
 .btn {
+  display: inline-block;
   background-color: $orange;
   color: $off-white;
   padding: 0.5rem 1rem;

--- a/rails/app/constraints/role_routing_constraint.rb
+++ b/rails/app/constraints/role_routing_constraint.rb
@@ -5,7 +5,6 @@ class RoleRoutingConstraint
 
   def matches?(request)
     user = current_user(request)
-    puts user
     user.present? && @block.call(user)
   end
 

--- a/rails/app/controllers/concerns/feature_flipper.rb
+++ b/rails/app/controllers/concerns/feature_flipper.rb
@@ -1,0 +1,22 @@
+# Note: Feature Flipper should only be used on Super Admin routes!
+module FeatureFlipper
+  extend ActiveSupport::Concern
+
+  def enable
+    feature = FlipperFeature.find_by(key: params[:feature_id])
+    feature.enable(
+      actor: Community.find_by(id: params[:community_id]),
+      group: params[:group]
+    )
+    redirect_to request.referrer
+  end
+
+  def disable
+    feature = FlipperFeature.find_by(key: params[:feature_id])
+    feature.disable(
+      actor: Community.find_by(id: params[:community_id]),
+      group: params[:group]
+    )
+    redirect_to request.referrer
+  end
+end

--- a/rails/app/controllers/dashboard/communities_controller.rb
+++ b/rails/app/controllers/dashboard/communities_controller.rb
@@ -1,0 +1,21 @@
+module Dashboard
+  class CommunitiesController < ApplicationController
+    def show
+      @community = authorize current_user.community
+    end
+
+    def update
+      @community = authorize current_user.community
+
+      @community.update(community_params)
+    end
+
+    private
+
+    def community_params
+      params.require(:community).permit(
+        :beta
+      )
+    end
+  end
+end

--- a/rails/app/controllers/super_admin/features_controller.rb
+++ b/rails/app/controllers/super_admin/features_controller.rb
@@ -1,0 +1,58 @@
+module SuperAdmin
+  class FeaturesController < ApplicationController
+    include FeatureFlipper
+
+    def index
+      @features = FlipperFeature.all.order(:key)
+    end
+
+    def show
+      @feature = FlipperFeature.find_by(key: params[:id])
+    end
+
+    def new
+      @feature = FlipperFeature.new
+    end
+
+    def create
+      @feature = FlipperFeature.new(feature_params)
+
+      if @feature.save
+        redirect_to feature_path(@feature.key)
+      else
+        flash.alert = "Unable to create feature"
+        render :new
+      end
+    end
+
+    def edit
+      @feature = FlipperFeature.find_by(key: params[:id])
+    end
+
+    def update
+      @feature = FlipperFeature.find_by(key: params[:id])
+      if @feature.update(feature_params)
+        redirect_to feature_path(@feature.key)
+      else
+        flash.alert = "Unable to update feature"
+        render :edit
+      end
+    end
+
+    def destroy
+      @feature = FlipperFeature.find_by(key: params[:id])
+      @feature.remove
+
+      flash.notice = "Feature Deleted: #{@feature.key}"
+      redirect_to features_path
+    end
+
+    private
+
+    def feature_params
+      params.require(:flipper_feature).permit(
+        :key, :description
+      )
+    end
+  end
+end

--- a/rails/app/models/community.rb
+++ b/rails/app/models/community.rb
@@ -24,6 +24,19 @@ class Community < ApplicationRecord
       .map { |x| x.updated_at  }
       .max
   end
+
+  # Flipper Feature Groups
+  # See config/initializers/flipper.rb to view registered groups
+  def feature_groups
+    Flipper.groups.each_with_object([]) do |group, arr|
+      arr << group.name if self.respond_to?(group.name) ? self.send(group.name) : self.send("#{group.name}_group?")
+    end
+  end
+
+  # Flipper `developers` group conditions
+  def developers_group?
+    name.match?("Ruby for Good")
+  end
 end
 
 # == Schema Information

--- a/rails/app/models/community.rb
+++ b/rails/app/models/community.rb
@@ -44,6 +44,7 @@ end
 # Table name: communities
 #
 #  id         :bigint           not null, primary key
+#  beta       :boolean          default(FALSE)
 #  country    :string
 #  locale     :string
 #  name       :string

--- a/rails/app/models/flipper_feature.rb
+++ b/rails/app/models/flipper_feature.rb
@@ -1,0 +1,71 @@
+# This model is backed by Flipper
+class FlipperFeature < ApplicationRecord
+  validates :key, presence: true, format: {with: /\A[a-zA-Z\_]+\z/}
+
+  def enabled?
+    Flipper.enabled?(key)
+  end
+
+  def enable(actor: nil, group: nil)
+    if actor
+      feature.enable_actor(actor)
+    elsif group
+      feature.enable_group(group)
+    else
+      feature.enable
+    end
+    touch
+  end
+
+  def disable(actor: nil, group: nil)
+    if actor
+      feature.disable_actor(actor)
+    elsif group
+      feature.disable_group(group)
+    else
+      feature.disable
+    end
+    touch
+  end
+
+  def actors
+    actors_value.map do |actor|
+      klass, id = actor.split(";")
+      klass.constantize.find_by(id: id)
+    end
+  end
+
+  def all_groups
+    feature.enabled_groups + feature.disabled_groups
+  end
+
+  def feature
+    Flipper[key]
+  end
+
+  def state_status
+    case feature.state
+    when :off
+      "Disabled"
+    else
+      "Enabled"
+    end
+  end
+
+  delegate :remove, :enabled_gate_names, :actors_value, :groups, :state, to: :feature
+end
+
+# == Schema Information
+#
+# Table name: flipper_features
+#
+#  id          :bigint           not null, primary key
+#  description :text
+#  key         :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+# Indexes
+#
+#  index_flipper_features_on_key  (key) UNIQUE
+#

--- a/rails/app/views/dashboard/communities/show.html.erb
+++ b/rails/app/views/dashboard/communities/show.html.erb
@@ -1,0 +1,18 @@
+<% content_for(:title) do %>
+  <%= t("dashboard.community.settings") %>
+<% end %>
+
+<% content_for(:main_heading) do %>
+  <h2><%= t("dashboard.community.settings") %></h2>
+<% end %>
+
+<%= form_with model: @community, url: community_settings_path, data: {remote: false}, class: "form aligned" do |f| %>
+  <%# Community Beta / Experimental Features %>
+  <h4><%= t("dashboard.community.beta_access") %></h4>
+  <div class="input-group">
+    <%= f.check_box :beta, checked: @community.beta %>
+    <%= f.label :beta %>
+  </div>
+
+  <%= f.submit %>
+<% end %>

--- a/rails/app/views/layouts/dashboard.html.erb
+++ b/rails/app/views/layouts/dashboard.html.erb
@@ -20,8 +20,9 @@
       <nav>
         <%= image_tag "logocombo.svg", alt: "Terrastories", class: "header--logo" %>
         <% if current_user.super_admin %>
-          <%= link_to "Metrics", metrics_path, class: ("active-link" if params[:controller] == "dashboard/metrics") %>
-          <%= link_to t("communities"), communities_path, class: ("active-link" if params[:controller] == "dashboard/communities") %>
+          <%= link_to "Metrics", metrics_path, class: ("active-link" if params[:controller] == "super_admin/metrics") %>
+          <%= link_to t("communities"), communities_path, class: ("active-link" if params[:controller] == "super_admin/communities") %>
+          <%= link_to "Features", features_path, class: ("active-link" if params[:controller] == "super_admin/features") %>
         <% else %>
           <h1><%= community.name %></h1>
           <%= link_to t("stories"), stories_path, class: ("active-link" if params[:controller] == "dashboard/stories") %>

--- a/rails/app/views/super_admin/communities/_form.html.erb
+++ b/rails/app/views/super_admin/communities/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: @community, multipart: true, data: {remote: false}, class: "form" do |f| %>
+<%= form_with model: @community, multipart: true, data: {remote: false}, locale: true, class: "form" do |f| %>
   <%= render partial: "shared/form_errors", locals: { resource: @community } %>
 
   <%= f.label :name, class: "required" %>

--- a/rails/app/views/super_admin/communities/show.html.erb
+++ b/rails/app/views/super_admin/communities/show.html.erb
@@ -14,21 +14,72 @@
 
 <%= render partial: "super_admin/metrics/metrics", locals: {stories_count: @community.stories.size, speakers_count: @community.speakers.size, places_count: @community.places.size, users_count: @community.users.size} %>
 
-<h3><%= t("users") %></h3>
-
-<table>
-  <thead>
-    <tr>
-      <th><%= User.human_attribute_name("username") %></th>
-      <th><%= User.human_attribute_name("role") %></th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @community.users.each do |user| %>
+<div class="two-columns columns-50-50">
+<div>
+  <h3>Features</h3>
+  <table>
+    <thead>
       <tr>
-        <td><%= user.username %></td>
-        <td><%= User.human_attribute_name("role.#{user.role}") %></td>
+        <th>Feature</th>
+        <th>Status</th>
+        <th>Groups</th>
+        <th></th>
       </tr>
-    <% end %>
-  </tbody>
-</table>
+    </thead>
+    <tbody>
+      <% Flipper.features.each do |feature| %>
+        <tr>
+          <td><%= feature.name %></td>
+          <td>
+            <% if feature.enabled?(@community) %>
+              <span class="badge badge__state badge__state-on">Enabled</span>
+            <% else %>
+              <span class="badge badge__state badge__state-off">Disabled</span>
+            <% end %>
+          </td>
+          <td>
+            <% if feature.enabled? %>
+              <span class="badge badge__state badge__state-on">Everyone</span>
+            <% else %>
+              <span class="badge badge__state badge__state-<%= feature.actors_value.include?(@community.flipper_id) ? 'on' : 'disabled' %>">self</span>
+              <% @community.feature_groups.each do |group| %>
+                <span class="badge badge__state badge__state-<%= feature.groups.map(&:name).include?(group) ? 'on' : 'disabled' %>"><%= group %></span>
+              <% end %>
+            <% end %>
+          </td>
+          <td>
+            <% if feature.enabled?(@community) %>
+              <% if feature.enabled_gate_names.include?(:actor) && feature.actors_value.include?(@community.flipper_id) %>
+                <%= link_to "Disable", feature_disable_path(feature.key, community_id: @community.id), method: :post %>
+              <% else %>
+                can't be disabled individually
+              <% end %>
+            <% else %>
+              <%= link_to "Enable", feature_enable_path(feature.key, community_id: @community.id), method: :post %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>
+<div>
+  <h3><%= t("users") %></h3>
+  <table>
+    <thead>
+      <tr>
+        <th><%= User.human_attribute_name("username") %></th>
+        <th><%= User.human_attribute_name("role") %></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @community.users.each do |user| %>
+        <tr>
+          <td><%= user.username %></td>
+          <td><%= User.human_attribute_name("role.#{user.role}") %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>
+</div>

--- a/rails/app/views/super_admin/features/_form.html.erb
+++ b/rails/app/views/super_admin/features/_form.html.erb
@@ -1,0 +1,11 @@
+<%= form_with model: @feature, local: true, url: features_path, class: "form aligned" do |f| %>
+  <% if @feature.new_record? %>
+    <%= f.label :key, "Name", class: "required" %>
+    <%= f.text_field :key, placeholder: "my_feature_name" %>
+    <p class="small">Feature names should be lower snake-case: e.g. cool_feature, cool</p>
+  <% end %>
+  <%= f.label :description %>
+  <%= f.text_area :description %>
+
+  <%= f.submit %>
+<% end %>

--- a/rails/app/views/super_admin/features/edit.html.erb
+++ b/rails/app/views/super_admin/features/edit.html.erb
@@ -1,0 +1,9 @@
+<% content_for(:title) do %>
+  Feature Flags
+<% end %>
+
+<% content_for :main_heading do %>
+  <h2>Edit Feature Flag: <%= @feature.key %></h2>
+<% end %>
+
+<%= render partial: "form" %>

--- a/rails/app/views/super_admin/features/index.html.erb
+++ b/rails/app/views/super_admin/features/index.html.erb
@@ -1,0 +1,47 @@
+<% content_for(:title) do %>
+  Features
+<% end %>
+
+<% content_for :main_heading do %>
+<div class="columns">
+  <h2>Feature Flags</h2>
+  <%= link_to t("dashboard.actions.new"), new_feature_path, class: "btn" %>
+<% end %>
+
+<table>
+<thead>
+  <th>Feature</th>
+  <th>Status</th>
+  <th>Enabled for</th>
+  <th></th>
+</thead>
+<tbody>
+<% @features.each do |feature| %>
+  <tr>
+    <td><%= feature.key %></td>
+    <td>
+      <span class="badge badge__state badge__state-<%= feature.state %>"><%= feature.state_status %></span>
+    </td>
+    <td>
+      <% if feature.enabled? %>
+        <span class="badge badge__state-all">Everyone</span>
+      <% end %>
+      <% feature.groups.each do |group| %>
+        <span class="badge badge__state-group"><%= group.name %></span>
+      <% end %>
+      <% if feature.actors_value.any? %>
+        <span class="badge badge__state-community">community</span>
+      <% end %>
+    </td>
+    <td>
+      <%= link_to "View", feature_path(feature.key) %>
+      <% if feature.enabled? %>
+        <%= link_to "Disable", feature_disable_path(feature.key), method: :post, data: {confirm: "Are you sure you want to disable this feature for everyone?"} %>
+      <% else %>
+        <%= link_to "Enable", feature_enable_path(feature.key), method: :post, data: {confirm: "Are you sure you want to enable this feature for everyone?"} %>
+      <% end %>
+    </td>
+  </tr>
+<% end %>
+</tbody>
+</table>

--- a/rails/app/views/super_admin/features/new.html.erb
+++ b/rails/app/views/super_admin/features/new.html.erb
@@ -1,0 +1,9 @@
+<% content_for(:title) do %>
+  Feature Flags
+<% end %>
+
+<% content_for :main_heading do %>
+  <h2>Add Feature Flag</h2>
+<% end %>
+
+<%= render partial: "form" %>

--- a/rails/app/views/super_admin/features/show.html.erb
+++ b/rails/app/views/super_admin/features/show.html.erb
@@ -1,0 +1,84 @@
+<% content_for(:title) do %>
+  <%= @feature.key %> | Feature Flags
+<% end %>
+
+<% content_for :main_heading do %>
+  <div class="columns">
+  <h2>
+    <div class="small">
+      <span class="badge badge__state-<%= @feature.feature.state %>">
+        <% if @feature.feature.on? %>
+          Enabled for everyone
+        <% elsif @feature.feature.conditional? %>
+          Enabled for some
+        <% else %>
+          Disabled for all
+        <% end %>
+      </span>
+    </div>
+    Feature: <%= @feature.key %>
+  </h2>
+    <div class="actions">
+      <%= link_to "Edit", edit_feature_path(@feature.key), class: "btn" %>
+      <%= link_to "Delete", feature_path(@feature.key), class: "btn btn-danger", method: :delete, data: {confirm: "Are you sure you want to remove this feature? If any flags still exist in the code, removing this feature effectively disables the feature."} %>
+    </div>
+  </div>
+<% end %>
+
+<% if @feature.description.present? %>
+  <p><%= @feature.description %></p>
+<% end %>
+
+<div class="two-columns columns-50-50">
+  <div>
+    <h4>Communities</h4>
+    <% if @feature.actors.any? %>
+      <p>Enable this feature directly on a <%= link_to "Community", communities_path %>.</p>
+      <p><%= link_to "Enable for everyone", feature_enable_path(@feature.key), class: "btn", method: :post, data: {confirm: "Are you sure you want to disable this feature for everyone?"} %></p>
+      <table><tbody>
+        <% @feature.actors.each do |actor| %>
+          <tr>
+            <td><%= link_to actor.name, actor %></td>
+            <td>
+              <%= link_to "Disable", feature_disable_path(@feature.key, community_id: actor.id), method: :post %>
+            </td>
+          </tr>
+        <% end %>
+      <tbody></table>
+    <% else %>
+      <% if @feature.enabled? %>
+        <p>This feature is enabled for all communities.</p>
+        <p><%= link_to "Disable for everyone", feature_disable_path(@feature.key), class: "btn", method: :post, data: {confirm: "Are you sure you want to disable this feature for everyone?"} %></p>
+      <% else %>
+        <p>Enable or disable this feature on a <%= link_to "Community", communities_path %>.</p>
+        <p><%= link_to "Enable for everyone", feature_enable_path(@feature.key), class: "btn", method: :post, data: {confirm: "Are you sure you want to enable this feature for everyone?"} %></p>
+      <% end %>
+    <% end %>
+  </div>
+  <div>
+    <h4>Groups</h4>
+    <% if @feature.all_groups.any? %>
+      <table><tbody>
+        <% @feature.all_groups.each do |group| %>
+          <tr>
+            <td><%= group.name %></td>
+            <td>
+              <% if @feature.groups.include?(group) %>
+                <span class="badge badge__state badge__state-on">Enabled</span>
+              <% else %>
+                <span class="badge badge__state badge__state-disabled">Disabled</span>
+              <% end %>
+            </td>
+            <td>
+              <% if @feature.groups.include?(group) %>
+                <%= link_to "Disable", feature_disable_path(@feature.key, group: group.name), method: :post %>
+              <% else %>
+                <%= link_to "Enable", feature_enable_path(@feature.key, group: group.name), method: :post %>
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
+      <tbody></table>
+    <% end %>
+  </div>
+</div>

--- a/rails/app/views/super_admin/metrics/_metrics.html.erb
+++ b/rails/app/views/super_admin/metrics/_metrics.html.erb
@@ -1,26 +1,26 @@
 <div class="collection">
   <% if local_assigns[:communities_count] %>
-    <div class="card card--center">
+    <div class="card card--center card--metrics">
       <span class="metric"><%= local_assigns[:communities_count] %></span>
       <h3><%= t("communities") %></h3>
     </div>
   <% end %>
-  <div class="card card--center">
+  <div class="card card--center card--metrics">
     <span class="metric"><%= local_assigns[:stories_count] %></span>
     <h3><%= t("stories") %></h3>
   </div>
 
-  <div class="card card--center">
+  <div class="card card--center card--metrics">
     <span class="metric"><%= local_assigns[:places_count] %></span>
     <h3><%= t("places") %></h3>
   </div>
 
-  <div class="card card--center">
+  <div class="card card--center card--metrics">
     <span class="metric"><%= local_assigns[:speakers_count] %></span>
     <h3><%= t("speakers") %></h3>
   </div>
 
-  <div class="card card--center">
+  <div class="card card--center card--metrics">
     <span class="metric"><%= local_assigns[:users_count] %></span>
     <h3><%= t("users") %></h3>
   </div>

--- a/rails/config/application.rb
+++ b/rails/config/application.rb
@@ -22,9 +22,11 @@ module App
     # Setup i18n Module
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '*', '*.{rb,yml}').to_s]
     config.i18n.available_locales = Dir[Rails.root.join('config','locales', '*')].map {|f| File.basename(f).to_sym }
-    # By default, locales will fallback to default locale, unless otherwise specified.
     config.i18n.default_locale = :en
-    config.i18n.fallbacks = { mat: [:nl, :en] }
+    # Set default locale fallback to :en
+    config.i18n.fallbacks.defaults = [:en]
+    # and configure language-specific fallbacks when needed
+    config.i18n.fallbacks.map = {mat: [:nl, :en]}
 
     # Don't replace existing images on upload for has_many_attached
     config.active_storage.replace_on_assign_to_many = false

--- a/rails/config/initializers/flipper.rb
+++ b/rails/config/initializers/flipper.rb
@@ -1,0 +1,3 @@
+Flipper.register(:developers) do |actor|
+  actor.respond_to?(:developers_group?) && actor.developers_group?
+end

--- a/rails/config/initializers/flipper.rb
+++ b/rails/config/initializers/flipper.rb
@@ -1,3 +1,7 @@
 Flipper.register(:developers) do |actor|
   actor.respond_to?(:developers_group?) && actor.developers_group?
 end
+
+Flipper.register(:beta) do |actor|
+  actor.respond_to?(:beta) && actor.beta
+end

--- a/rails/config/locales/en/models.en.yml
+++ b/rails/config/locales/en/models.en.yml
@@ -93,6 +93,7 @@ en:
       story: Story
       theme: Theme
       media_link: Media Link
+      flipper_feature: Feature
     # Used for model-based form labels and other attribute displays
     attributes:
       place:

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -35,6 +35,10 @@ Rails.application.routes.draw do
 
       resource :metrics, only: :show
       resources :communities
+      resources :features do
+        post :enable
+        post :disable
+      end
     end
 
     devise_for :users, :controllers => { registrations: 'registrations' }

--- a/rails/db/migrate/20221104205654_create_flipper_tables.rb
+++ b/rails/db/migrate/20221104205654_create_flipper_tables.rb
@@ -1,0 +1,23 @@
+class CreateFlipperTables < ActiveRecord::Migration[6.1]
+  def self.up
+    create_table :flipper_features do |t|
+      t.string :key, null: false
+      t.text :description
+      t.timestamps null: false
+    end
+    add_index :flipper_features, :key, unique: true
+
+    create_table :flipper_gates do |t|
+      t.string :feature_key, null: false
+      t.string :key, null: false
+      t.string :value
+      t.timestamps null: false
+    end
+    add_index :flipper_gates, [:feature_key, :key, :value], unique: true
+  end
+
+  def self.down
+    drop_table :flipper_gates
+    drop_table :flipper_features
+  end
+end

--- a/rails/db/migrate/20221107214122_add_beta_to_community.rb
+++ b/rails/db/migrate/20221107214122_add_beta_to_community.rb
@@ -1,0 +1,5 @@
+class AddBetaToCommunity < ActiveRecord::Migration[6.1]
+  def change
+    add_column :communities, :beta, :boolean, default: false
+  end
+end

--- a/rails/db/schema.rb
+++ b/rails/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_04_183628) do
+ActiveRecord::Schema.define(version: 2022_11_04_205654) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -69,6 +69,23 @@ ActiveRecord::Schema.define(version: 2022_10_04_183628) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_curriculums_on_user_id"
+  end
+
+  create_table "flipper_features", force: :cascade do |t|
+    t.string "key", null: false
+    t.text "description"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["key"], name: "index_flipper_features_on_key", unique: true
+  end
+
+  create_table "flipper_gates", force: :cascade do |t|
+    t.string "feature_key", null: false
+    t.string "key", null: false
+    t.string "value"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true
   end
 
   create_table "media_links", force: :cascade do |t|

--- a/rails/db/schema.rb
+++ b/rails/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_04_205654) do
+ActiveRecord::Schema.define(version: 2022_11_07_214122) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -50,6 +50,7 @@ ActiveRecord::Schema.define(version: 2022_11_04_205654) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "theme_id"
+    t.boolean "beta", default: false
   end
 
   create_table "curriculum_stories", force: :cascade do |t|


### PR DESCRIPTION
This adds the ability for super admins to add and manage feature flags.

Features can be added, edited (description only), and removed.
Features can be enabled and disabled for a Community.
Features can be enabled and disabled for a Group (beta or developers).
Features can be enabled and disabled for everyone.

Note: at the moment, features can be added; but will have **no impact** on the app at this time.

Some screenshots:

**Feature Flag Index**
<img width="1315" alt="image" src="https://user-images.githubusercontent.com/2660801/200429562-18bf2249-1de5-431f-9185-6448f8f49c8c.png">

**View a Feature Flag**
<img width="1315" alt="image" src="https://user-images.githubusercontent.com/2660801/200429915-70a64354-a198-4325-9c66-7b6e823cefa0.png">

**View enabled/disabled features for a given Community**
<img width="1315" alt="image" src="https://user-images.githubusercontent.com/2660801/200429618-b99b5d33-8f6a-4120-8548-dd9ee1f9632a.png">
