### PR TITLE
chore: add m4a mime type

### DIFF
--- a/rails/app/models/place.rb
+++ b/rails/app/models/place.rb
@@ -9,7 +9,7 @@ class Place < ApplicationRecord
   has_one_attached :name_audio
   validates :name, presence: true
   validates :photo, blob: { content_type: ['image/png', 'image/jpg', 'image/jpeg'] }
-  validates :name_audio, blob: { content_type: ['audio/mpeg', 'audio/wav'] }
+  validates :name_audio, blob: { content_type: ['audio/mpeg', 'audio/wav', 'audio/m4a'] }
   validates :lat, numericality: { greater_than_or_equal_to:  -90, less_than_or_equal_to:  90, message: :invalid_latitude }, allow_blank: true
   validates :long, numericality: { greater_than_or_equal_to: -180, less_than_or_equal_to: 180, message: :invalid_longitude}, allow_blank: true
   has_many :interview_stories, class_name: "Story", foreign_key: "interview_location_id"

--- a/rails/app/models/place.rb
+++ b/rails/app/models/place.rb
@@ -9,7 +9,7 @@ class Place < ApplicationRecord
   has_one_attached :name_audio
   validates :name, presence: true
   validates :photo, blob: { content_type: ['image/png', 'image/jpg', 'image/jpeg'] }
-  validates :name_audio, blob: { content_type: ['audio/mpeg', 'audio/wav', 'audio/m4a'] }
+  validates :name_audio, blob: { content_type: ['audio/mpeg', 'audio/wav', 'audio/mp4', 'audio/m4a', 'audio/x-m4a', 'audio/x-aac', 'audio/x-flac'] }
   validates :lat, numericality: { greater_than_or_equal_to:  -90, less_than_or_equal_to:  90, message: :invalid_latitude }, allow_blank: true
   validates :long, numericality: { greater_than_or_equal_to: -180, less_than_or_equal_to: 180, message: :invalid_longitude}, allow_blank: true
   has_many :interview_stories, class_name: "Story", foreign_key: "interview_location_id"

--- a/rails/app/models/story.rb
+++ b/rails/app/models/story.rb
@@ -14,7 +14,7 @@ class Story < ApplicationRecord
   validates :title, presence: true
   validates :speaker_ids, presence: true
   validates :place_ids, presence: true
-  validates :media, blob: { content_type: ['image/png', 'image/jpg', 'image/jpeg', 'video/mpeg', 'video/mp4', 'video/quicktime', 'video/webm', 'audio/mpeg', 'audio/wav', 'audio/m4a'] }
+  validates :media, blob: { content_type: ['image/png', 'image/jpg', 'image/jpeg', 'video/mpeg', 'video/mp4', 'video/quicktime', 'video/webm', 'audio/mpeg', 'audio/wav', 'audio/mp4', 'audio/m4a', 'audio/x-m4a', 'audio/x-aac', 'audio/x-flac'] }
 
   def self.import_csv(file_contents, community)
     ApplicationController.helpers.csv_importer(file_contents, self, community)

--- a/rails/app/models/story.rb
+++ b/rails/app/models/story.rb
@@ -14,7 +14,7 @@ class Story < ApplicationRecord
   validates :title, presence: true
   validates :speaker_ids, presence: true
   validates :place_ids, presence: true
-  validates :media, blob: { content_type: ['image/png', 'image/jpg', 'image/jpeg', 'video/mpeg', 'video/mp4', 'video/quicktime', 'video/webm', 'audio/mpeg', 'audio/wav'] }
+  validates :media, blob: { content_type: ['image/png', 'image/jpg', 'image/jpeg', 'video/mpeg', 'video/mp4', 'video/quicktime', 'video/webm', 'audio/mpeg', 'audio/wav', 'audio/m4a'] }
 
   def self.import_csv(file_contents, community)
     ApplicationController.helpers.csv_importer(file_contents, self, community)


### PR DESCRIPTION
One of our users tried to add an m4a audio recording (from iPhone) to `name_audio` in the Place model, and she wasn't able to because we currently only permit mpeg and wav.

This is a quick PR to add m4a mime type to media attachments for stories and places (place name). 

