### PR TITLE
Github actions to publish to Docker Hub on new release and new PR

### DIFF
--- a/.github/workflows/push-docker-development.yml
+++ b/.github/workflows/push-docker-development.yml
@@ -1,0 +1,31 @@
+name: push-docker-development
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build-push-docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@v4
+        with:
+          short-length: 8 # Same as v3 and before
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: "{{defaultContext}}:rails"
+          push: true
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          tags: terrastories/terrastories:${{ env.GITHUB_REF_SLUG }}

--- a/.github/workflows/push-docker-production.yml
+++ b/.github/workflows/push-docker-production.yml
@@ -1,0 +1,46 @@
+name: push-docker-production
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build-push-docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push latest
+        uses: docker/build-push-action@v3
+        with:
+          context: "{{defaultContext}}:rails"
+          push: true
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          tags: terrastories/terrastories:latest
+      - name: Get the Ref
+        id: get-ref
+        uses: ankitvgupta/ref-to-tag-action@master
+        with:
+          ref: ${{ github.ref }}
+          head_ref: ${{ github.head_ref }}
+      - name: Build and push version
+        uses: docker/build-push-action@v3
+        with:
+          context: "{{defaultContext}}:rails"
+          push: true
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          tags: "terrastories/terrastories:${{steps.get-ref.outputs.tag}}"
+      - name: Docker Hub Description
+        uses: peter-evans/dockerhub-description@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: terrastories/terrastories
+          short-description: 'Terrastories is a geostorytelling application built to enable local communities to locate and map their own oral storytelling traditions about places of significant meaning or value to them. Check out our Wiki for open source development information.'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ![Terrastories](https://www.amazonteam.org/wp-content/uploads/2018/09/logo-1170x164.png)
 
+![Docker Hub Image](https://github.com/terrastories/terrastories/actions/push-docker-production.yml/badge.svg)
+
 ## Table of Contents
 
 1. [About Terrastories](#about-terrastories)


### PR DESCRIPTION
In order to get this working a person with access to publish to Docker Hub needs to add `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` as Action secrets to this repo's settings.

## Development behavior
Is triggered whenever a **new PR to the `master` branch** is created.
- Builds Docker images for: linux/amd64,linux/arm64,linux/arm/v7
- Publishes them with a tag which is the slugified version of the branch name

## Production behavior
Is triggered whenever a **new release** is created.
- Builds Docker images for: linux/amd64,linux/arm64,linux/arm/v7
- Publishes them with the `latest` tag as well as the tag version of the release
- Generates the Docker Hub description based on the README.md

## Possibilities
It's possible to have the action automatically create a release on Github with the changelog, could be whenever a new tag is published to Github