### PR TITLE
Feat: Mark Community for Public Exploration

### DIFF
--- a/rails/app/controllers/dashboard/communities_controller.rb
+++ b/rails/app/controllers/dashboard/communities_controller.rb
@@ -8,13 +8,16 @@ module Dashboard
       @community = authorize current_user.community
 
       @community.update(community_params)
+
+      redirect_to community_settings_path
     end
 
     private
 
     def community_params
       params.require(:community).permit(
-        :beta
+        :beta,
+        :public
       )
     end
   end

--- a/rails/app/models/community.rb
+++ b/rails/app/models/community.rb
@@ -48,7 +48,12 @@ end
 #  country    :string
 #  locale     :string
 #  name       :string
+#  public     :boolean          default(FALSE), not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #  theme_id   :integer
+#
+# Indexes
+#
+#  index_communities_on_public  (public)
 #

--- a/rails/app/policies/community_policy.rb
+++ b/rails/app/policies/community_policy.rb
@@ -10,7 +10,11 @@ class CommunityPolicy < ApplicationPolicy
   end
 
   def show?
-    true
+    return true if user.super_admin
+    return true if user.admin? &&
+      (Flipper.enabled?(:split_settings, community) || Flipper.enabled?(:public_community, community))
+
+    false
   end
 
   def new?
@@ -22,7 +26,8 @@ class CommunityPolicy < ApplicationPolicy
   end
 
   def edit?
-    user.super_admin || user.admin?
+    user.super_admin || (user.admin? &&
+      (Flipper.enabled?(:split_settings, community) || Flipper.enabled?(:public_community, community)))
   end
 
   def update?

--- a/rails/app/policies/community_policy.rb
+++ b/rails/app/policies/community_policy.rb
@@ -12,7 +12,7 @@ class CommunityPolicy < ApplicationPolicy
   def show?
     return true if user.super_admin
     return true if user.admin? &&
-      (Flipper.enabled?(:split_settings, community) || Flipper.enabled?(:public_community, community))
+      (Flipper.enabled?(:split_settings, community) || Flipper.enabled?(:public_communities, community))
 
     false
   end
@@ -27,7 +27,7 @@ class CommunityPolicy < ApplicationPolicy
 
   def edit?
     user.super_admin || (user.admin? &&
-      (Flipper.enabled?(:split_settings, community) || Flipper.enabled?(:public_community, community)))
+      (Flipper.enabled?(:split_settings, community) || Flipper.enabled?(:public_communities, community)))
   end
 
   def update?

--- a/rails/app/views/dashboard/communities/show.html.erb
+++ b/rails/app/views/dashboard/communities/show.html.erb
@@ -7,6 +7,15 @@
 <% end %>
 
 <%= form_with model: @community, url: community_settings_path, data: {remote: false}, class: "form aligned" do |f| %>
+  <% if Flipper.enabled?(:public_communities, @community) %>
+    <%# Community Public %>
+    <h4><%= t("dashboard.community.make_public") %></h4>
+    <div class="input-group">
+      <%= f.check_box :public, checked: @community.public %>
+      <%= f.label :public %>
+    </div>
+  <% end %>
+
   <%# Community Beta / Experimental Features %>
   <h4><%= t("dashboard.community.beta_access") %></h4>
   <div class="input-group">

--- a/rails/app/views/layouts/dashboard.html.erb
+++ b/rails/app/views/layouts/dashboard.html.erb
@@ -37,6 +37,9 @@
           <%= link_to t("users"), users_path, class: ("active-link" if params[:controller] == "dashboard/users") %>
           <%= link_to t("theme"), edit_theme_path, class: ("active-link" if params[:controller] == "dashboard/theme") %>
           <%= link_to t("import"), import_path, class: ("active-link" if params[:controller] == "dashboard/import") %>
+          <% if Flipper.enabled?(:public_communities, community) || Flipper.enabled?(:split_settings) %>
+            <%= link_to t("community.settings"), community_settings_path, class: ("active-link" if params[:controller] == "dashboard/community") %>
+          <% end %>
         <% end %>
         <div class="language-picker">
           <h5><%= t("language") %></h5>

--- a/rails/config/locales/en/dashboard.en.yml
+++ b/rails/config/locales/en/dashboard.en.yml
@@ -26,6 +26,9 @@ en:
       last_updated_on: Last updated on %{last_updated_on}
     back_to_app: Back to App
     community_settings: Community Settings
+    community:
+      settings: Settings
+      make_public: Public exploration of your community
     headings:
       new_resource: New %{name}
     actions:

--- a/rails/config/locales/en/models.en.yml
+++ b/rails/config/locales/en/models.en.yml
@@ -11,6 +11,9 @@ en:
   helpers:
     label:
       visibility: Visibility
+      community:
+        public: Enable public interface
+        beta: Enable experimental beta features
       speaker:
         one: Speaker
         name: Name

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -5,8 +5,9 @@ Rails.application.routes.draw do
       root to: "stories#index", as: :member_root
 
       get :search, to: "search#index"
-
       get :profile, to: "users#profile", as: :user_profile
+
+      resource :community, only: [:show, :update], as: :community_settings
       resources :users do
         delete :photo, action: :delete_photo
       end

--- a/rails/db/migrate/20221027172631_add_public_flag_to_community.rb
+++ b/rails/db/migrate/20221027172631_add_public_flag_to_community.rb
@@ -1,0 +1,6 @@
+class AddPublicFlagToCommunity < ActiveRecord::Migration[6.1]
+  def change
+    add_column :communities, :public, :boolean, default: false, null: false
+    add_index :communities, :public
+  end
+end

--- a/rails/db/schema.rb
+++ b/rails/db/schema.rb
@@ -51,6 +51,8 @@ ActiveRecord::Schema.define(version: 2022_11_07_214122) do
     t.datetime "updated_at", null: false
     t.integer "theme_id"
     t.boolean "beta", default: false
+    t.boolean "public", default: false, null: false
+    t.index ["public"], name: "index_communities_on_public"
   end
 
   create_table "curriculum_stories", force: :cascade do |t|


### PR DESCRIPTION
### ⚠️ This feature is behind a feature flag!!
(and also doesn't really do anything outwardly, I'm just trying to keep PR's small and feature flags allow us to build more incrementally)

This adds the ability for communities to opt-in to their Community being publicly explorable.

At the point, opting in does not serve any purpose, so this feature is behind a feature flag until more of the feature can be built out.

## Testing

1. Log in as a Super Admin and create the `public_communities` feature.
2. Enable it for your preferred community or the `developer` group which will enable the `public_communities` feature for any community that matches "Ruby for Good"
3. Log out, and log back in using the Admin account for the enabled community.
4. Note: There should be a new Admin link to "Settings"
    <img width="170" alt="image" src="https://user-images.githubusercontent.com/2660801/201391788-0e374b55-c006-4382-97d0-659b9e008156.png">
5. Communities can now enable Beta Access and/or Public Exploration
    <img width="366" alt="image" src="https://user-images.githubusercontent.com/2660801/201391980-6066d9ed-872e-45b1-a965-b35f64f16b00.png">
6. Note: There is also a secondary flag, `split_settings` which can be enabled separately or in conjunction — for now enabling this but not public communities will simply provide the new link and the ability to enable Beta access.