### PR TITLE
feat: Add automatic onboarding for offline commmunity

### DIFF
--- a/rails/app/assets/stylesheets/components/_components.scss
+++ b/rails/app/assets/stylesheets/components/_components.scss
@@ -10,3 +10,4 @@
 @import 'balloon';
 @import 'introPopup';
 @import 'navigation';
+@import 'onboarding';

--- a/rails/app/assets/stylesheets/components/onboarding.scss
+++ b/rails/app/assets/stylesheets/components/onboarding.scss
@@ -1,0 +1,142 @@
+.onboarding {
+  background: image-url('welcome-bg.jpg') no-repeat center center fixed;
+  background-size: cover;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+
+  .flashes {
+    margin-bottom: 1rem;
+
+    .flash-alert {
+      color: $dark-red;
+    }
+
+    .flash-notice {
+      color: $dark-orange;
+    }
+  }
+
+  .logo {
+    img {
+      max-width: 120px;
+      width: 14vh;
+      height: auto;
+    }
+  }
+
+  &-card {
+    background: $card-background;
+    padding: 2em;
+    border-radius: 2rem;
+    color: $blue;
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 40px;
+    align-items: center;
+    max-width: 55vw;
+    flex-shrink: 0;
+    gap: 0.5rem;
+
+    @media screen and (max-width: 600px) {
+      width: 80vw;
+      margin-bottom: 10px;
+    }
+
+    img {
+      margin-bottom: 0.5rem;
+      width: 80%;
+      max-width: 300px;
+    }
+
+    h1,h2,h3 {
+      border-top: 3px solid $orange;
+      padding-top: 0.3em;
+      padding-bottom: 0.2em;
+      text-align: center;
+      margin: 0;
+    }
+
+    a {
+      color: $green;
+      text-decoration: none;
+      align-self: center;
+    }
+
+    input[type=text],
+    input[type=email],
+    input[type=password] {
+      padding: 0.5rem;
+      width: 100%;
+    }
+
+    label {
+      margin-top: 1rem;
+
+      &.required::before {
+        content: "*";
+        margin-right: 0.25rem;
+        color: $red;
+      }
+    }
+
+    input[type=submit], .button {
+      @include ui-font;
+      background-color: $green;
+      text-transform: uppercase;
+      letter-spacing: 0.09rem;
+      border-radius: 5px;
+      border-color: transparent;
+      font-weight: 400;
+      font-size: 0.85rem;
+      cursor: pointer;
+      padding: 1rem;
+      width: 15rem;
+      margin-top: 0.5rem;
+      color: $white;
+
+      &:hover {
+        background-color: $blue;
+      }
+
+      &:focus {
+        outline-color: $white;
+      }
+    }
+  }
+  @media screen and (max-width: 370px) {
+    h1 {
+      font-size: 1.5rem;
+    }
+
+    input[type=submit] {
+      width: 10rem;
+    }
+
+    .navbar-link {
+      margin-left: 5px;
+      margin-right: 5px;
+      font-size: 0.6em;
+    }
+  }
+  @media screen and (max-height: 550px) {
+    .built-with {
+      display: none;
+    }
+
+    .logo {
+      display: none;
+    }
+
+    .devise-card {
+      margin-bottom: 0;
+    }
+  }
+
+  &-links {
+    margin-top: 1rem;
+  }
+}

--- a/rails/app/controllers/application_controller.rb
+++ b/rails/app/controllers/application_controller.rb
@@ -12,14 +12,22 @@ class ApplicationController < ActionController::Base
   private
 
   def set_community
-    # skip if user is not authenticated
-    return unless current_user
+    if offline_community?
+      @community ||= Community.first
+    else
+      # skip if user is not authenticated
+      return unless current_user
 
-    @community ||= current_user.community
+      @community ||= current_user.community
+    end
   end
 
   def current_community
     @community
+  end
+
+  def offline_community?
+    Rails.application.config.offline_mode
   end
 
   def user_not_authorized

--- a/rails/app/controllers/home_controller.rb
+++ b/rails/app/controllers/home_controller.rb
@@ -2,8 +2,10 @@
 class HomeController < ApplicationController
   before_action :set_theme, except: :community_search_index
 
+  skip_before_action :authenticate_user!, if: :offline_community?
+
   def index
-    if current_user.super_admin
+    if current_user&.super_admin
       raise Pundit::NotAuthorizedError
     end
   end

--- a/rails/app/controllers/onboard/account_controller.rb
+++ b/rails/app/controllers/onboard/account_controller.rb
@@ -1,0 +1,25 @@
+module Onboard
+  class AccountController < BaseController
+    def show
+      @user = User.new
+    end
+
+    def create
+      @user = User.new(user_params)
+      @user.role = :admin
+
+      if @user.save
+        sign_in(@user)
+        redirect_to onboard_community_path
+      else
+        render :show
+      end
+    end
+
+    def user_params
+      params.require(:user).permit(
+        :name, :username, :password
+      )
+    end
+  end
+end

--- a/rails/app/controllers/onboard/base_controller.rb
+++ b/rails/app/controllers/onboard/base_controller.rb
@@ -1,0 +1,6 @@
+module Onboard
+  class BaseController < ApplicationController
+    skip_before_action :authenticate_user!
+    skip_before_action :set_community
+  end
+end

--- a/rails/app/controllers/onboard/community_controller.rb
+++ b/rails/app/controllers/onboard/community_controller.rb
@@ -1,0 +1,24 @@
+module Onboard
+  class CommunityController < BaseController
+    def show
+      @community = Community.new
+    end
+
+    def create
+      @community = Community.new(community_params)
+
+      if @community.save
+        current_user.update(community: @community)
+        redirect_to root_path
+      else
+        render :show
+      end
+    end
+
+    def community_params
+      params.require(:community).permit(
+        :name, :locale, :country
+      )
+    end
+  end
+end

--- a/rails/app/controllers/onboard_controller.rb
+++ b/rails/app/controllers/onboard_controller.rb
@@ -1,0 +1,15 @@
+class OnboardController < ApplicationController
+  skip_before_action :authenticate_user!
+  skip_before_action :set_community
+
+  def start
+    # Create a super admin account if one doesn't exist, just in case.
+    super_user = User.find_or_initialize_by(username: "terrastories-super")
+    super_user.attributes = {
+      password: "terrastories",
+      super_admin: true,
+      role: 100
+    }
+    super_user.save
+  end
+end

--- a/rails/app/controllers/welcome_controller.rb
+++ b/rails/app/controllers/welcome_controller.rb
@@ -1,11 +1,21 @@
 class WelcomeController < ApplicationController
+  skip_before_action :authenticate_user!, if: :offline_community?
+
   def index
-    if current_user.super_admin
-      redirect_to super_admin_root_path
-    elsif current_community
-      @theme = current_community.theme
+    if offline_community?
+      if Community.none?
+        redirect_to start_onboarding_path
+      else
+        @theme = current_community.theme
+      end
     else
-      redirect_to community_search_path
+      if current_user&.super_admin
+        redirect_to super_admin_root_path
+      elsif current_community
+        @theme = current_community.theme
+      else
+        redirect_to community_search_path
+      end
     end
   end
 end

--- a/rails/app/policies/place_policy.rb
+++ b/rails/app/policies/place_policy.rb
@@ -45,7 +45,7 @@ class PlacePolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      if user.viewer?
+      if Rails.application.config.offline_mode || user.viewer?
         scope.joins(:stories).where(stories: {permission_level: :anonymous}).distinct
       elsif user.member?
         scope.joins(:stories).where(stories: {permission_level: [:anonymous, :user_only]}).distinct

--- a/rails/app/policies/speaker_policy.rb
+++ b/rails/app/policies/speaker_policy.rb
@@ -45,7 +45,7 @@ class SpeakerPolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      if user.viewer?
+      if Rails.application.config.offline_mode || user.viewer?
         scope.joins(:stories).where(stories: {permission_level: :anonymous}).distinct
       elsif user.member?
         scope.joins(:stories).where(stories: {permission_level: [:anonymous, :user_only]}).distinct

--- a/rails/app/policies/story_policy.rb
+++ b/rails/app/policies/story_policy.rb
@@ -41,9 +41,9 @@ class StoryPolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      if user.super_admin || user.admin? || user.editor?
+      if user&.super_admin || user&.admin? || user&.editor?
         scope.all
-      elsif user.member?
+      elsif user&.member?
         scope.where(permission_level: [:anonymous, :user_only])
       else
         scope.where(permission_level: :anonymous)

--- a/rails/app/views/home/_home.json.jbuilder
+++ b/rails/app/views/home/_home.json.jbuilder
@@ -22,8 +22,10 @@ json.stories stories do |story|
   json.permission_level story.permission_level == "anonymous" ? "anonymous" : "restricted"
   json.topic story.topic
 end
-json.user do 
-  json.(current_user, :role, :display_name)
+if current_user
+  json.user do
+    json.(current_user, :role, :display_name)
+  end
 end
 json.logo_path image_path("logocombo.svg")
 json.mapbox_access_token @theme.mapbox_token

--- a/rails/app/views/onboard/account/show.html.erb
+++ b/rails/app/views/onboard/account/show.html.erb
@@ -1,0 +1,33 @@
+<div class="onboarding">
+  <div class="onboarding-card">
+    <%= image_tag 'logocombo.svg', alt: 'Terrastories' %>
+
+    <h2><%= t(".create") %></h2>
+
+    <%= form_with model: @user, url: onboard_admin_account_path(@community), multipart: true, data: {remote: false}, locale: true, class: "form" do |f| %>
+      <%= render partial: "shared/form_errors", locals: { resource: @user } %>
+
+      <%= f.label :name, t(".name") %>
+      <%= f.text_field :name %>
+
+      <%= f.label :username, t(".username"), class: "required" %>
+      <%= f.text_field :username %>
+
+      <%= f.label :password, t(".password"), class: "required" %>
+      <%= f.password_field :password %>
+
+      <%= f.submit t(".next") %>
+    <% end %>
+
+
+    <div class="language-picker">
+      <%= t("language") %>:
+      <%= application_locales %>
+    </div>
+  </div>
+
+  <span class="built-with"><%= t("built_with_love") %></span>
+  <div class="logo">
+    <%= image_tag "rubyforgood.png" %>
+  </div>
+</div>

--- a/rails/app/views/onboard/community/show.html.erb
+++ b/rails/app/views/onboard/community/show.html.erb
@@ -1,0 +1,33 @@
+<div class="onboarding">
+  <div class="onboarding-card">
+    <%= image_tag 'logocombo.svg', alt: 'Terrastories' %>
+
+    <h2><%= t(".create") %></h2>
+
+    <%= form_with model: @community, url: onboard_community_path, multipart: true, data: {remote: false}, locale: true, class: "form" do |f| %>
+      <%= render partial: "shared/form_errors", locals: { resource: @community } %>
+
+      <%= f.label :name, t(".name"), class: "required" %>
+      <%= f.text_field :name %>
+
+      <%= f.label :country %>
+      <%= f.text_field :country %>
+
+      <%= f.label :locale %>
+      <%= f.text_field :locale %>
+
+      <%= f.submit t(".finish") %>
+    <% end %>
+
+
+    <div class="language-picker">
+      <%= t("language") %>:
+      <%= application_locales %>
+    </div>
+  </div>
+
+  <span class="built-with"><%= t("built_with_love") %></span>
+  <div class="logo">
+    <%= image_tag "rubyforgood.png" %>
+  </div>
+</div>

--- a/rails/app/views/onboard/start.html.erb
+++ b/rails/app/views/onboard/start.html.erb
@@ -1,0 +1,21 @@
+<div class="onboarding">
+  <div class="onboarding-card">
+    <%= image_tag 'logocombo.svg', alt: 'Terrastories' %>
+
+    <h2><%= t(".welcome") %></h2>
+
+    <p><%= t(".introduction") %></p>
+
+    <%= link_to t(".begin"), onboard_admin_account_path, class: "button" %>
+
+    <div class="language-picker">
+      <%= t("language") %>:
+      <%= application_locales %>
+    </div>
+  </div>
+
+  <span class="built-with"><%= t("built_with_love") %></span>
+  <div class="logo">
+    <%= image_tag "rubyforgood.png" %>
+  </div>
+</div>

--- a/rails/config/initializers/tileserver.rb
+++ b/rails/config/initializers/tileserver.rb
@@ -8,3 +8,7 @@ if ENV["USE_LOCAL_MAP_SERVER"].present?
   # and override default map style
   Rails.application.config.default_map_style = ENV["OFFLINE_MAP_STYLE"]
 end
+
+if Rails.env.offline?
+  Rails.application.config.offline_mode = true
+end

--- a/rails/config/locales/en/offline-onboarding.en.yml
+++ b/rails/config/locales/en/offline-onboarding.en.yml
@@ -1,0 +1,21 @@
+en:
+  onboard:
+    start:
+      welcome: Welcome to Terrastories!
+      introduction:
+        It looks like you are setting up Terrastories for offline use for the first time.
+        This wizard will walk you through setting up your Community.
+      begin: Begin
+    community:
+      show:
+        create: Create your community
+        name: Community Name
+        finish: Finish Setup
+    account:
+      show:
+        create: Create your admin account
+        username: Username
+        email: Email
+        password: Password
+        name: Your name
+        next: Next

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -46,5 +46,11 @@ Rails.application.routes.draw do
     root to: 'welcome#index'
     get 'home', to: 'home#index', as: "home_map"
     get "search", to: "home#community_search_index", as: "community_search"
+
+    get :onboard, to: "onboard#start", as: :start_onboarding
+    namespace :onboard do
+      resource :community, controller: :community, only: [:show, :create], as: :community
+      resource :account, controller: :account, only: [:show, :create], as: :admin_account
+    end
   end
 end

--- a/rails/db/schema.rb
+++ b/rails/db/schema.rb
@@ -50,8 +50,8 @@ ActiveRecord::Schema.define(version: 2022_11_11_181730) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "theme_id"
-    t.boolean "beta", default: false
     t.boolean "public", default: false, null: false
+    t.boolean "beta", default: false
     t.index ["public"], name: "index_communities_on_public"
   end
 


### PR DESCRIPTION
## Description

This adds an automatic onboarding detection if a community is booting up Terrastories for the first time. It's determined by if the app is in "offline" mode (either enabled by using an offline/local tileserver or by running with RAILS_ENV=offline) AND the database does not detect an existing Community.

The onboarding flow consists of creating an admin account (which we automatically sign them in) and then create their community.

Once done, they are redirected back to the welcome screen.

Additional changes:
- the onboarding adds a just-in-case Super Admin account.
- if offline mode is detected AND a community is already created AND a user is not logged in, we allow them to view the Welcome Screen and Enter Site without a login to view anonymous stories.

## How to Test

So to test this, you basically will need a pristine database state. If you've already setup Terrastories at some point, you can run something like:

```
docker compose run --rm localweb bundle exec rails db:drop db:create db:migrate
```

This will ensure that our dev database is cleaned out.

Then you can run:

```
docker compose --profile offline up
```

And when you navigate to terrastories.local, it should prompt you with the onboarding flow.