### PR TITLE
fix: change admin page to member dashboard

### DIFF
--- a/rails/app/javascript/components/Card.jsx
+++ b/rails/app/javascript/components/Card.jsx
@@ -47,7 +47,7 @@ class Card extends Component {
       return (
         <ul>
           <li>{I18n.t("hello")} {this.props.user.display_name} (<a href={`/${I18n.currentLocale()}`}>{I18n.t("back_to_welcome")}</a>)</li>
-          <li><a href={`/${I18n.currentLocale()}/member`}>{I18n.t("admin_page")}</a></li>
+          <li><a href={`/${I18n.currentLocale()}/member`}>{I18n.t("member_dashboard")}</a></li>
         </ul>
       );
     } else if (this.props.user) {

--- a/rails/app/views/welcome/index.html.erb
+++ b/rails/app/views/welcome/index.html.erb
@@ -13,11 +13,8 @@
 
     <div class="welcome-card-user">
       <% if user_signed_in? %>
-        <% if current_user.admin? || current_user.editor? %>
           <%= link_to t("member_dashboard"), member_root_path, :class => 'navbar-link' %> |
-        <% else %>
-          <%= link_to t("community"), member_root_path, :class => 'navbar-link' %> |
-        <% end %>
+      <% end %>
         <%= link_to t("logout"), destroy_user_session_path, method: :delete, :class => 'navbar-link'  %>
       <% else %>
         <%= link_to t("login"), new_user_session_path, :class => 'navbar-link'  %>

--- a/rails/app/views/welcome/index.html.erb
+++ b/rails/app/views/welcome/index.html.erb
@@ -14,7 +14,7 @@
     <div class="welcome-card-user">
       <% if user_signed_in? %>
         <% if current_user.admin? || current_user.editor? %>
-          <%= link_to t("admin_page"), member_root_path, :class => 'navbar-link' %> |
+          <%= link_to t("member_dashboard"), member_root_path, :class => 'navbar-link' %> |
         <% else %>
           <%= link_to t("community"), member_root_path, :class => 'navbar-link' %> |
         <% end %>

--- a/rails/config/locales/am/am.yml
+++ b/rails/config/locales/am/am.yml
@@ -25,7 +25,7 @@ am:
     zh: ቻይንኛ
 
   # Front End Translations
-  admin_page: "የአስተዳዳሪ ገጽ"
+  member_dashboard: "የአስተዳዳሪ ገጽ"
   alphabetical: A-Z
   back_to_map: "ወደ ካርታ ተመለስ"
   back_to_welcome: "ወደ የእንኳን ደህና መጡ ገጽ ተመለስ"

--- a/rails/config/locales/en/en.yml
+++ b/rails/config/locales/en/en.yml
@@ -25,7 +25,7 @@ en:
     zh: Chinese
 
   # Front End Translations
-  admin_page: "Admin Page"
+  member_dashboard: "Member Dashboard"
   alphabetical: A-Z
   back_to_map: "Back to Map"
   back_to_welcome: "Back to Welcome Page"

--- a/rails/config/locales/es/es.yml
+++ b/rails/config/locales/es/es.yml
@@ -25,7 +25,7 @@ es:
     zh: Chino
 
   # Front End Translations
-  admin_page: "Página de administración"
+  member_dashboard: "Tablero de Miembros"
   alphabetical: A-Z
   back_to_map: "Volver al Mapa"
   back_to_welcome: "Volver a la página de inicio"

--- a/rails/config/locales/hi/hi.yml
+++ b/rails/config/locales/hi/hi.yml
@@ -27,7 +27,7 @@ hi:
     pu: पंजाबी
 
   # Front End Translations
-  admin_page: "व्यवस्थापक पृष्ठ"
+  member_dashboard: "व्यवस्थापक पृष्ठ"
   alphabetical: वर्णमाला क्रम (A-Z)
   back_to_map: "मानचित्र पर वापस जाएं"
   back_to_welcome: "स्वागत पृष्ठ पर वापस जाएं"

--- a/rails/config/locales/ja/ja.yml
+++ b/rails/config/locales/ja/ja.yml
@@ -25,7 +25,7 @@ ja:
     zh: 中国語
 
   # Front End Translations
-  admin_page: "管理ページ"
+  member_dashboard: "管理ページ"
   alphabetical: A-Z
   back_to_map: "マップに戻る"
   back_to_welcome: "入り口に戻る"

--- a/rails/config/locales/mat/mat.yml
+++ b/rails/config/locales/mat/mat.yml
@@ -25,7 +25,7 @@ mat:
     zh: Snesi
 
   # Front End Translations
-  admin_page: "Admin pagina"
+  member_dashboard: "Ledendashboard"
   alphabetical: "A-Z"
   back_to_map: "Go ko na kaita"
   back_to_welcome: "Go ko na bigi"

--- a/rails/config/locales/nl/nl.yml
+++ b/rails/config/locales/nl/nl.yml
@@ -25,7 +25,7 @@ nl:
     zh: Chinees
 
   # Front End Translations
-  admin_page: "Admin pagina"
+  member_dashboard: "Ledendashboard"
   alphabetical: "A-Z"
   back_to_map: "Terug naar de kaart"
   back_to_welcome: "Terug naar Welkom pagina"

--- a/rails/config/locales/pt/pt.yml
+++ b/rails/config/locales/pt/pt.yml
@@ -25,7 +25,7 @@ pt:
     zh: Chinês
 
   # Front End Translations
-  admin_page: "Página de administração"
+  member_dashboard: "Painel de Membros"
   alphabetical: "A-Z"
   back_to_map: "Voltar ao mapa"
   back_to_welcome: "Voltar para página inicial"

--- a/rails/config/locales/pu/pu.yml
+++ b/rails/config/locales/pu/pu.yml
@@ -27,7 +27,7 @@ pu:
     pu: ਪੰਜਾਬੀ
 
   # Front End Translations
-  admin_page: "ਪ੍ਰਬੰਧਕ ਪੰਨਾ"
+  member_dashboard: "ਪ੍ਰਬੰਧਕ ਪੰਨਾ"
   alphabetical: A-Z
   back_to_map: "ਨਕਸ਼ੇ 'ਤੇ ਵਾਪਸ"
   back_to_welcome: "ਵਾਪਸ ਸੁਆਗਤ ਪੰਨੇ 'ਤੇ"

--- a/rails/config/locales/sw/sw.yml
+++ b/rails/config/locales/sw/sw.yml
@@ -25,7 +25,7 @@ sw:
     zh: Kichina
 
   # Front End Translations
-  admin_page: "Ukurasa wa Msimamizi"
+  member_dashboard: "Ukurasa wa Msimamizi"
   alphabetical: A-Z
   back_to_map: "Rudi kwenye Ramani"
   back_to_welcome: "Rudi kwenye Ukurasa wa Karibu"

--- a/rails/config/locales/zh/zh.yml
+++ b/rails/config/locales/zh/zh.yml
@@ -25,7 +25,7 @@ zh:
     zh: 中國人
 
   # Front End Translations
-  admin_page: "管理页面"
+  member_dashboard: "管理页面"
   alphabetical: A-Z
   back_to_map: "返回地图"
   back_to_welcome: "返回欢迎页"


### PR DESCRIPTION
This PR changes the term "admin page" to "member dashboard" (as well as string `admin_page` to `member_dashboard`. Changes made across the i18n files although we will have to solicit new translations for non-Western languages in the future.