### PR TITLE
897.docker rubygems error

### DIFF
--- a/rails/Dockerfile
+++ b/rails/Dockerfile
@@ -18,7 +18,7 @@ RUN apk --no-cache add --update \
     imagemagick \
     ffmpeg && \
     gem install rubygems-update -v '<3' --no-document && update_rubygems && \
-    gem install bundler --no-document --force
+    gem install bundler --no-document --force -v '~> 2.3.0'
 
 WORKDIR /api
 

--- a/rails/Dockerfile
+++ b/rails/Dockerfile
@@ -17,7 +17,7 @@ RUN apk --no-cache add --update \
     libc6-compat \
     imagemagick \
     ffmpeg && \
-    gem update --system --no-document && \
+    gem install rubygems-update -v '<3' --no-document && update_rubygems && \
     gem install bundler --no-document --force
 
 WORKDIR /api


### PR DESCRIPTION
- Fix error with rubygems-update
- Pin bundler version to avoid error with Ruby 2.5.9
