### PR TITLE
Include new translations by clearing cache and precompiling assets

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -26,6 +26,7 @@ services:
       - 3000:3000
     expose:
       - "3000"
+    command: sh -c "bundle exec rake tmp:cache:clear && bundle exec rake assets:precompile && bundle exec rails s -b '0.0.0.0'"
     environment:
       - CHECK_BUNDLER=yes
     volumes:
@@ -64,6 +65,7 @@ services:
       - 3030:3030
     expose:
       - "3030"
+    command: sh -c "bundle exec rake tmp:cache:clear && bundle exec rake assets:precompile && bundle exec rails s -b '0.0.0.0'"
     volumes:
       - bundler:/usr/local/bundle
       - ./rails:/api


### PR DESCRIPTION
Fixes [#856](https://github.com/Terrastories/terrastories/issues/856) 

Currently, we're relying on the `i18n-js` gem and utilizing it through the asset pipeline for our translations. When adding a new locale, these changes aren't being reflected on the front end. Only after changing any of the existing `yml` files will the fingerprint for the assets be updated and trigger a refresh. 

After doing some digging, this is actually the intended design by Sprockets.

Relevant issue: [#213 within i18n-js](https://github.com/fnando/i18n-js/issues/213)
Provided Workarounds: https://github.com/fnando/i18n-js/tree/v3#missing-translations-in-precompiled-files-after-adding-any-new-locale-file

For this PR, I went with the first option of calling rake tasks on the rails container after it's spun up. These commands clear the cache and force a precompile of all the assets. Because the cache has been cleared, it picks up all existing locales(old and new) and provides them to the front end. I've tested on both `offline` and `dev` profiles with the following steps:

1. `bin/setup`
2. `docker compose --profile dev up` or `docker compose --profile offline up`
3.  Load `localhost:3000` and confirm splash page with translations
4.  Add a new locale: inside of `config/locales`, `cp -r en/ it/` then modify all `yml` files within the new directory from the `en` to `it` key
5. Kill  `docker compose` with ctrl+c and rerun the command from step 2
6. Load `localhost:3000` and new it translations will be present

While this won't "hot load" new translations, it will ensure anything new will be included at the start of the rails container. 

Option 2 from the `i18n-js` docs  is what we're already doing.
Option 3 from the `i18n-js` docs might be an easier and better solution, but wanted to discuss on path forward. 