### PR TITLE
Update Gemfile ruby version to 2.7.8

### DIFF
--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.7.7'
+ruby '2.7.8'
 
 # lock mail version (required by rails)
 # until upgrade to Ruby 3 / Rails 7


### PR DESCRIPTION
It looks like the ruby:2.7-alpine image was updated to 2.7.8 in https://github.com/docker-library/ruby/commit/7117899e1b7d3d8230fe8021acf76ead8d2f5230
since terrastories was updated

Fixes this error
```
 => ERROR [devcore 5/6] RUN bundle config set --local path /usr/local/bundle &&     bundle config build.nokog  2.1s
------
 > [devcore 5/6] RUN bundle config set --local path /usr/local/bundle &&     bundle config build.nokogiri --use-system-libraries &&     bundle install:

0 2.032 Your Ruby version is 2.7.8, but your Gemfile specified 2.7.7
```
