### PR TITLE
Foreman/Procfile fixes for offline mode

### DIFF
--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -87,6 +87,8 @@ group :development do
 
   # annotate models
   gem "annotate"
+
+  gem "foreman"
 end
 
 group :test do

--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.7.7'
+ruby '2.7.8'
 
 # lock mail version (required by rails)
 # until upgrade to Ruby 3 / Rails 7

--- a/rails/Gemfile.lock
+++ b/rails/Gemfile.lock
@@ -139,6 +139,7 @@ GEM
     flipper-active_record (0.26.0)
       activerecord (>= 4.2, < 8)
       flipper (~> 0.26.0)
+    foreman (0.87.2)
     formatador (1.1.0)
     geocoder (1.8.1)
     globalid (1.1.0)
@@ -180,12 +181,10 @@ GEM
     method_source (1.0.0)
     mini_magick (4.12.0)
     mini_mime (1.1.2)
-    mini_portile2 (2.8.1)
     minitest (5.17.0)
     nenv (0.3.0)
     nio4r (2.5.8)
-    nokogiri (1.14.2)
-      mini_portile2 (~> 2.8.0)
+    nokogiri (1.14.2-aarch64-linux)
       racc (~> 1.4)
     notiffany (0.1.3)
       nenv (~> 0.1)
@@ -331,7 +330,7 @@ GEM
     zeitwerk (2.6.7)
 
 PLATFORMS
-  ruby
+  aarch64-linux-musl
 
 DEPENDENCIES
   activestorage-validator (~> 0.2.0)
@@ -348,6 +347,7 @@ DEPENDENCIES
   factory_bot_rails
   flipper (~> 0.26.0)
   flipper-active_record (~> 0.26.0)
+  foreman
   geocoder (~> 1.8.1)
   guard-rspec
   image_processing (~> 1.12.2)
@@ -374,7 +374,7 @@ DEPENDENCIES
   webpacker (~> 5.0)
 
 RUBY VERSION
-   ruby 2.7.7p221
+   ruby 2.7.8p225
 
 BUNDLED WITH
-   2.4.7
+   2.4.12

--- a/rails/Procfile.dev
+++ b/rails/Procfile.dev
@@ -1,3 +1,3 @@
-web: unset PORT && bin/rails server --binding 0.0.0.0
+web: bin/rails server --binding 0.0.0.0
 css: yarn build:css --watch
 webpack: bin/webpack-dev-server

--- a/rails/bin/dev
+++ b/rails/bin/dev
@@ -1,8 +1,3 @@
 #!/usr/bin/env sh
 
-if ! gem list foreman -i --silent; then
-  echo "Installing foreman..."
-  gem install foreman
-fi
-
-exec foreman start -f Procfile.dev "$@"
+bundle exec foreman start -f Procfile.dev "$@"


### PR DESCRIPTION
- Respect PORT from compose.yaml in Procfile.dev
  with `unset PORT`, we were ignoring the localweb 3030 port for offline mode, so we'd be stuck on the nginx loading screen because rails was running on port 3000
- Add foreman in gemfile and use bundle exec to run it
  Without this change, we run into this error when trying to run offline mode without internet for the first time

```
terrastories-localweb-1     | Installing foreman...
terrastories-localweb-1     | ERROR:  Could not find a valid gem 'foreman' (>= 0), here is why:
terrastories-localweb-1     |           Unable to download data from https://rubygems.org/ - SocketError: Failed to open TCP connection to rubygems.org:443 (getaddrinfo: Name does not resolve) (https://rubygems.org/specs.4.8.gz)
terrastories-localweb-1     | ./bin/dev: exec: line 8: foreman: not found
```
