### PR TITLE
Fix Offline Mode Configuration & Setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -136,8 +136,18 @@ docker compose up -d db
 ## build app
 docker compose --profile $profile build
 
-## setup and seed database
-docker compose --profile $profile run --rm $container bin/rails db:migrate db:seed
+## setup database
+docker compose --profile $profile run --rm $container bin/rails db:migrate
+
+## Seed database with demo data
+if [[ "$profile" = "dev" ]]; then
+  docker compose --profile dev run --rm $container bin/rails db:seed
+fi
+
+## Precompile assets for offline mode
+if [[ "$profile" = "offline" ]]; then
+  docker compose --profile offline run --rm -e RAILS_ENV=offline $container bin/rails assets:precompile
+fi
 
 ## run yarn
 docker compose --profile $profile run --rm $container yarn

--- a/compose.yaml
+++ b/compose.yaml
@@ -71,7 +71,7 @@ services:
       - ./data/media:/media
       - ./data/import/media:/api/import/media
     environment:
-      - RAILS_ENV=${RAILS_ENV-development}
+      - RAILS_ENV=${RAILS_ENV-offline}
       - PORT=3030
       - VIRTUAL_PORT=3030
       - VIRTUAL_HOST=terrastories.local,${HOST_HOSTNAME-terrastories.local}

--- a/rails/.gitignore
+++ b/rails/.gitignore
@@ -52,6 +52,7 @@ node_modules/
 # Ignore coverage reports
 rails/spec/javascript/coverage/*
 
+/public/offline-assets
 /public/assets
 /public/packs
 /public/packs-test

--- a/rails/Dockerfile
+++ b/rails/Dockerfile
@@ -8,7 +8,7 @@
 # == Development Image
 #
 # Also used as the base for building assets for prod images.
-FROM ruby:2.7-alpine as devcore
+FROM ruby:2.7.7-alpine as devcore
 
 RUN apk --no-cache add --update \
     build-base \
@@ -51,7 +51,7 @@ RUN bundle exec rake assets:precompile
 #
 # Start from base Ruby image so we can keep image size slim
 # Final image can be used for online or offline mode.
-FROM ruby:2.7-alpine as prod
+FROM ruby:2.7.7-alpine as prod
 
 EXPOSE 3000
 

--- a/rails/config/database.yml
+++ b/rails/config/database.yml
@@ -61,4 +61,4 @@ production:
   url: <%= ENV['DATABASE_URL'] %>
 
 offline:
-  url: <%= ENV.fetch('DATABASE_URL', 'postgresql://postgres:postgres@host.docker.internal:5432/terrastories-dev') %>
+  url: <%= ENV.fetch('DATABASE_URL', 'postgresql://postgres:postgres@db:5432/terrastories-dev') %>

--- a/rails/config/environments/offline.rb
+++ b/rails/config/environments/offline.rb
@@ -96,6 +96,8 @@ Rails.application.configure do
   # Compress CSS using a preproccessor
   # config.assets.css_compressor = :sass
 
+  config.assets.prefix = "/offline-assets"
+
   # Fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
 

--- a/rails/config/environments/offline.rb
+++ b/rails/config/environments/offline.rb
@@ -26,6 +26,31 @@ Rails.application.configure do
   # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
   config.require_master_key = false
 
+  # The secret_key_base is used as the input secret to the application's key
+  # generator, which in turn is used to create all MessageVerifiers/MessageEncryptors,
+  # including the ones that sign and encrypt cookies.
+  config.secret_key_base = lambda {
+    # Always use configured SECRET_KEY_BASE env var if one is configured
+    if ENV.fetch("SECRET_KEY_BASE", false)
+      secrets.secret_key_base ||= ENV["SECRET_KEY_BASE"]
+    else
+      key_file = Rails.root.join("tmp/offline_secret.txt")
+
+      # Generate and store "secret" in tmp/offline_secrets.txt
+      # This mirrors Rails automatic generation of secret in dev
+      # and test mode. We want to replicate it for seamless
+      # configuration in offline mode.
+      if !File.exists?(key_file)
+        random_key = SecureRandom.hex(64)
+        FileUtils.mkdir_p(key_file.dirname)
+        File.binwrite(key_file, random_key)
+      end
+
+      secrets.secret_key_base = File.binread(key_file)
+    end
+    secrets.secret_key_base
+  }.call
+
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 


### PR DESCRIPTION
These are a few of the issues that some of our community admins have been running into while setting up with Docker & Docker Compose.

1. The default DATABASE_URL was using docker's internal host rather than the service name as host.
2. `SECRET_KEY_BASE` was missing. RAILS_ENV=offline now correctly generates this on first-boot.
3. The official Ruby 2.7 docker image was updated with a minor patch, breaking our builds. We now lock the minor patch.
4. Prefix and precompile assets when booted into RAILS_ENV=offline mode.

These changes "break" (loosely) using the offline environment for development testing. Instead, it's recommended for developers enhancing offline mode to utilize development environment and set the OFFLINE_MAP_STYLE to the local running tileserver using the fully-qualified URL to the desired style (such as localhost:8080/styles/terrastories-map.json).

This isn't perfect, but it should unblock our members who are unable to set up with the latest version on GitHub.

I was able to successfully test setting up with the `bin/setup` script and doing no additional configuration adjustments.