### PR TITLE
Remove offline scope on policy_scope

### DIFF
--- a/rails/app/policies/place_policy.rb
+++ b/rails/app/policies/place_policy.rb
@@ -45,7 +45,7 @@ class PlacePolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      if Rails.application.config.offline_mode || user.viewer?
+      if user.viewer?
         scope.joins(:stories).where(stories: {permission_level: :anonymous}).distinct
       elsif user.member?
         scope.joins(:stories).where(stories: {permission_level: [:anonymous, :user_only]}).distinct

--- a/rails/app/policies/speaker_policy.rb
+++ b/rails/app/policies/speaker_policy.rb
@@ -41,7 +41,7 @@ class SpeakerPolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      if Rails.application.config.offline_mode || user.viewer?
+      if user.viewer?
         scope.joins(:stories).where(stories: {permission_level: :anonymous}).distinct
       elsif user.member?
         scope.joins(:stories).where(stories: {permission_level: [:anonymous, :user_only]}).distinct


### PR DESCRIPTION
Let it handle scoping by permissions; offline mode shouldn't change that.

This was causing runs booted with RAILS_ENV=offline to never allow admins or editors to view speakers or places that didn't have an anonymous story attached.