### PR TITLE
fix(import): Imports with file attachments failed

### DIFF
--- a/rails/app/models/concerns/importable.rb
+++ b/rails/app/models/concerns/importable.rb
@@ -106,7 +106,9 @@ module Importable
 
     def save_importable_records
       importable_rows.each do |row|
-        attributes = row.dup
+        # with_indifferent_access to allow key access as strings or symbols
+        # since CSV uses strings and AR uses symbols.
+        attributes = row.dup.with_indifferent_access
 
         # Remove media from attributes to attach later.
         media = @klass.attachment_attribute_names.each_with_object({}) do |k, hash|

--- a/rails/app/models/concerns/importable.rb
+++ b/rails/app/models/concerns/importable.rb
@@ -135,7 +135,7 @@ module Importable
         # Convert permissions if class headers includes `permission_level`
         # NOTE(@lauramosher): this was pulled from the old implementation; as we think about more
         # granulated story permissions, we may want to expand this conversion
-        if @mapped_headers.keys.include?(:permission_level)
+        if @mapped_headers.keys.include?("permission_level")
           attributes[:permission_level] = attributes[:permission_level]&.strip.blank? ? "anonymous" : "user_only"
         end
 

--- a/rails/spec/models/place_spec.rb
+++ b/rails/spec/models/place_spec.rb
@@ -28,20 +28,20 @@ RSpec.describe Place, type: :model do
 
   describe "#import" do
     let(:mapped_headers) {{
-      name: "name",
-      type_of_place: "type_of_place",
-      description: "description",
-      region: "region",
-      long: "long",
-      lat: "lat"
-    }}
+      "name" => "name",
+      "type_of_place" => "type_of_place",
+      "description" => "description",
+      "region" => "region",
+      "long" => "long",
+      "lat" => "lat"
+    }.to_h}
 
     it "raises HeaderMismatchError when mapped headers are missing" do
       expect {
         described_class.import(
           file_fixture('place_without_media.csv'),
           community.id,
-          mapped_headers.merge({photo: "other"})
+          mapped_headers.merge({"photo" => "other"})
         )
       }.to raise_error(Importable::FileImporter::HeaderMismatchError)
     end
@@ -64,7 +64,7 @@ RSpec.describe Place, type: :model do
             described_class.import(
               file_fixture('place_with_missing_media.csv'),
               community.id,
-              mapped_headers.merge({photo: "media"})
+              mapped_headers.merge({"photo" => "media"})
           )
           }.to change(described_class, :count).from(0).to(1)
         end
@@ -74,7 +74,7 @@ RSpec.describe Place, type: :model do
         described_class.import(
           file_fixture('place_with_media.csv'),
           community.id,
-          mapped_headers.merge({photo: "media"})
+          mapped_headers.merge({"photo" =>  "media"})
         )
         expect(described_class.last.photo).to be_attached
       end
@@ -83,7 +83,7 @@ RSpec.describe Place, type: :model do
         described_class.import(
           file_fixture('place_with_media.csv'),
           community.id,
-          mapped_headers.merge({name_audio: "audio"})
+          mapped_headers.merge({"name_audio" =>  "audio"})
         )
         expect(described_class.last.name_audio).to be_attached
       end

--- a/rails/spec/models/place_spec.rb
+++ b/rails/spec/models/place_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Place, type: :model do
       "region" => "region",
       "long" => "long",
       "lat" => "lat"
-    }.to_h}
+    }}
 
     it "raises HeaderMismatchError when mapped headers are missing" do
       expect {

--- a/rails/spec/models/speaker_spec.rb
+++ b/rails/spec/models/speaker_spec.rb
@@ -68,9 +68,9 @@ RSpec.describe Speaker, type: :model do
 
   describe "#import" do
     let(:mapped_headers) {{
-      name: "name",
-      birthdate: "birthdate",
-      birthplace_id: "birthplace"
+      "name" =>"name",
+      "birthdate" =>"birthdate",
+      "birthplace_id" =>"birthplace"
     }}
 
     it "raises HeaderMismatchError when mapped headers are missing" do
@@ -105,10 +105,10 @@ RSpec.describe Speaker, type: :model do
       end
 
       let(:mapped_headers) {{
-        name: "name",
-        birthdate: "birthdate",
-        birthplace_id: "birthplace",
-        photo: "photo"
+        "name" => "name",
+        "birthdate" => "birthdate",
+        "birthplace_id" => "birthplace",
+        "photo" => "photo"
       }}
 
       context "but media file is not found" do

--- a/rails/spec/models/story_spec.rb
+++ b/rails/spec/models/story_spec.rb
@@ -50,14 +50,14 @@ RSpec.describe Story, type: :model do
 
   describe "#import" do
     let(:mapped_headers) {{
-      title: "name",
-      desc: "description",
-      places: "places",
-      speakers: "speakers",
-      interview_location_id: "interview_location",
-      date_interviewed: "date_interviewed",
-      interviewer_id: "interviewer",
-      language: "language"
+      "title" => "name",
+      "desc" => "description",
+      "places" => "places",
+      "speakers" => "speakers",
+      "interview_location_id" => "interview_location",
+      "date_interviewed" => "date_interviewed",
+      "interviewer_id" => "interviewer",
+      "language" => "language"
     }}
 
     it "raises HeaderMismatchError when mapped headers are missing" do
@@ -110,15 +110,15 @@ RSpec.describe Story, type: :model do
       end
 
       let(:mapped_headers) {{
-        title: "name",
-        desc: "description",
-        places: "places",
-        speakers: "speakers",
-        interview_location_id: "interview_location",
-        date_interviewed: "date_interviewed",
-        interviewer_id: "interviewer",
-        language: "language",
-        media: "media"
+        "title" => "name",
+        "desc" => "description",
+        "places" => "places",
+        "speakers" => "speakers",
+        "interview_location_id" => "interview_location",
+        "date_interviewed" => "date_interviewed",
+        "interviewer_id" => "interviewer",
+        "language" => "language",
+        "media" => "media"
       }}
 
       context "but media file is not found" do
@@ -158,15 +158,15 @@ RSpec.describe Story, type: :model do
 
     context "when permission level is included in CSV" do
       let(:mapped_headers) {{
-        title: "name",
-        desc: "description",
-        places: "places",
-        speakers: "speakers",
-        interview_location_id: "interview_location",
-        date_interviewed: "date_interviewed",
-        interviewer_id: "interviewer",
-        language: "language",
-        permission_level: "permission_level"
+        "title" => "name",
+        "desc" => "description",
+        "places" => "places",
+        "speakers" => "speakers",
+        "interview_location_id" => "interview_location",
+        "date_interviewed" => "date_interviewed",
+        "interviewer_id" => "interviewer",
+        "language" => "language",
+        "permission_level" => "permission_level"
       }}
 
       it "sets permission level to nil when row is blank" do


### PR DESCRIPTION
This fixes an issue where imports that contained file attachments were not importing correctly despite green tests. This is because CSV used string headers and my tests were using symbol headers; this caused the tests to pass, but the actual import failed if the import file contained file attachments. Consequently, the import did work if no attachments were present.

This likely worked before — and why our click testing was successful when we QA'd this feature when it was first completed — until we upgraded to a version that no longer implicitly provided `with_indifferent_access` to hashy objects that allowed key comparison between string and symbols to work without additional code. I've updated the tests to use string keys and also added the explicit `with_indifferent_access` to ensure that we are not caught off-guard again.