### PR TITLE
Fix mapbox-gl.css import

### DIFF
--- a/rails/app/assets/stylesheets/dashboard.sass.scss
+++ b/rails/app/assets/stylesheets/dashboard.sass.scss
@@ -1,4 +1,4 @@
-@import 'mapbox-gl/dist/mapbox-gl.css';
+@import 'mapbox-gl/dist/mapbox-gl';
 
 @import 'core/reset';
 @import 'core/colors';


### PR DESCRIPTION
With the `.css` extension, we weren't actually inlining the CSS during
the build process, so we'd see the following issues in offline mode when
visiting a page that uses `dashboard.css` (e.g. http://terrastories.local/en/member/theme/edit)

a 404 for the `mapbox-gl.css` file
```
GET http://terrastories.local/offline-assets/mapbox-gl/dist/mapbox-gl.css net::ERR_ABORTED 404 (Not Found)
```

At the top of `rails/public/offline-assets/dashboard-<DIGEST>.css`, we'd
see this line

```
@import 'mapbox-gl/dist/mapbox-gl.css';
````

There were also some visual glitches which you can see in these screenshots.

<img width="888" alt="Screenshot 2023-07-06 at 2 13 14 PM" src="https://github.com/Terrastories/terrastories/assets/217050/1110222a-b87b-46b9-a702-d7ca1c2d3c12">


I noticed this when trying to set the marker for https://github.com/Terrastories/terrastories/issues/805.
After this change, the 404 is gone, the CSS is properly inlined in
`dashboard-<DIGEST>.css` and no visual glitches.

<img width="895" alt="Screenshot 2023-07-06 at 2 18 41 PM" src="https://github.com/Terrastories/terrastories/assets/217050/bb4a441d-d82d-4fd7-97dd-c9ac16216608">