### PR TITLE
Move the map center after editing the lat/long fields

### DIFF
--- a/rails/app/views/dashboard/themes/edit.html.erb
+++ b/rails/app/views/dashboard/themes/edit.html.erb
@@ -162,6 +162,8 @@
 
 <script>
 const themeForm = document.querySelector("#themeForm");
+const themeCenterLatInput = themeForm.querySelector("#theme_center_lat");
+const themeCenterLongInput = themeForm.querySelector("#theme_center_long");
 const zoomInput = themeForm.querySelector("#theme_zoom");
 const zoomValue = themeForm.querySelector("#zoomValue");
 const pitchInput = themeForm.querySelector("#theme_pitch");
@@ -185,8 +187,8 @@ const themeMap = new mapboxgl.Map({
 themeMap.on("moveend", (e) => {
   let themeForm = document.querySelector("#themeForm");
   let { lng, lat } = e.target.getCenter();
-  themeForm.querySelector("input#theme_center_long").value = lng.toFixed(5);
-  themeForm.querySelector("input#theme_center_lat").value = lat.toFixed(5);
+  themeCenterLongInput.value = lng.toFixed(5);
+  themeCenterLatInput.value = lat.toFixed(5);
 
   if (!themeForm.querySelector("input#unrestricted_bounds").checked) {
     let { _ne, _sw } = themeMap.getBounds();
@@ -226,6 +228,15 @@ themeForm.querySelector("input#unrestricted_bounds").addEventListener("click", (
     themeForm.querySelector("input#theme_sw_boundary_lat").value = _sw.lat.toFixed(5);
   }
 })
+
+themeCenterLongInput.addEventListener("change", (e) => {
+  let { lat } = themeMap.getCenter();
+  themeMap.setCenter({lng: e.target.value, lat: lat});
+});
+themeCenterLatInput.addEventListener("change", (e) => {
+  let { lng } = themeMap.getCenter();
+  themeMap.setCenter({lng: lng, lat: e.target.value});
+});
 
 zoomInput.addEventListener("input", (e) => {
   zoomValue.innerHTML = e.target.value;


### PR DESCRIPTION
When dragging the map around, the center coordinate input fields were synced to the
input fields. This PR implements syncing in the reverse direction in case the user wants to edit the coordinates
manually but wants to see where that is on the map visually.

![terrastories](https://github.com/Terrastories/terrastories/assets/217050/182f73a1-6365-41aa-bb0f-c14bf0bac634)

I originally tried to listen for [input event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event), but it would fire as the user is typing and modify the value to include the 5 fixed decimal points, which would effectively prevent the user from entering any values more than a single digit. So I am listening for [change event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event) instead, which has the small negative that it won't fire until the input field loses focus.

Also there is a small refactor to reuse the variables for the input fields

I noticed this while working on https://github.com/Terrastories/terrastories/issues/805



