### PR TITLE
Implement location picker map for places

### DIFF
--- a/rails/app/assets/stylesheets/dashboard.sass.scss
+++ b/rails/app/assets/stylesheets/dashboard.sass.scss
@@ -22,7 +22,7 @@
 @import 'cms/errors';
 @import 'cms/flash';
 
-#themeMap {
+#themeMap, #placeMap {
   min-height: 400px;
   min-width: 400px;
 }

--- a/rails/app/controllers/dashboard/places_controller.rb
+++ b/rails/app/controllers/dashboard/places_controller.rb
@@ -16,7 +16,7 @@ module Dashboard
     end
 
     def new
-      authorize @place = community_places.new
+      authorize @place = community_places.new(lat: 0, long: 0)
     end
 
     def create

--- a/rails/app/controllers/dashboard/places_controller.rb
+++ b/rails/app/controllers/dashboard/places_controller.rb
@@ -16,7 +16,10 @@ module Dashboard
     end
 
     def new
-      authorize @place = community_places.new(lat: 0, long: 0)
+      # set initial position and zoom using the current community's theme
+      current_theme = current_community.theme
+      @initial_zoom = current_theme.zoom
+      authorize @place = community_places.new(lat: current_theme.center_lat, long: current_theme.center_long)
     end
 
     def create

--- a/rails/app/controllers/dashboard/places_controller.rb
+++ b/rails/app/controllers/dashboard/places_controller.rb
@@ -16,10 +16,9 @@ module Dashboard
     end
 
     def new
-      # set initial position and zoom using the current community's theme
+      # set initial position using the current community's theme
       current_theme = current_community.theme
-      @initial_zoom = current_theme.zoom
-      authorize @place = community_places.new(lat: current_theme.center_lat, long: current_theme.center_long)
+      authorize @place = community_places.new(lat: current_theme.center_lat || 0, long: current_theme.center_long || 0)
     end
 
     def create

--- a/rails/app/views/dashboard/places/_form.html.erb
+++ b/rails/app/views/dashboard/places/_form.html.erb
@@ -60,7 +60,7 @@ const placeMap = new mapboxgl.Map({
   container: "placeMap", // container ID
   center: coordinates, // starting position [lng, lat]
   hash: false,
-  zoom: <%= @initial_zoom %>,
+  zoom: <%= current_community.theme.zoom || 5 %>, // starting zoom
   style: "<%= current_community.theme.mapbox_style %>", // style URL or style object
   cooperativeGestures: true
 });

--- a/rails/app/views/dashboard/places/_form.html.erb
+++ b/rails/app/views/dashboard/places/_form.html.erb
@@ -60,7 +60,7 @@ const placeMap = new mapboxgl.Map({
   container: "placeMap", // container ID
   center: coordinates, // starting position [lng, lat]
   hash: false,
-  zoom: 3, // starting zoom
+  zoom: <%= @initial_zoom %>,
   style: "<%= current_community.theme.mapbox_style %>", // style URL or style object
   cooperativeGestures: true
 });

--- a/rails/app/views/dashboard/places/_form.html.erb
+++ b/rails/app/views/dashboard/places/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: @place, multipart: true, data: {remote: false}, class: "form aligned" do |f| %>
+<%= form_with model: @place, multipart: true, data: {remote: false}, class: "form aligned", id: "place_form" do |f| %>
   <%= render partial: "shared/form_errors", locals: { resource: @place } %>
 
   <%= f.label :name, class: "required" %>
@@ -34,11 +34,57 @@
     <%= f.collection_check_boxes :story_ids, current_community.stories, :id, :title %>
   </div>
 
-  <%= f.label :lat %>
-  <%= f.text_field :lat %>
+  <div class="two-columns">
+    <div class="two-columns-left column-fixed-400">
+      <%= f.label :lat %>
+      <%= f.text_field :lat %>
 
-  <%= f.label :long %>
-  <%= f.text_field :long %>
+      <%= f.label :long %>
+      <%= f.text_field :long %>
+    </div>
+    <div class="two-columns-right">
+      <div id="placeMap"></div>
+    </div>
+  </div>
 
   <%= f.submit %>
 <% end %>
+
+<script>
+const placeForm = document.querySelector("#place_form");
+const placeLatInput = placeForm.querySelector("#place_lat");
+const placeLongInput = placeForm.querySelector("#place_long");
+const coordinates = [placeLongInput.value, placeLatInput.value]
+const placeMap = new mapboxgl.Map({
+  accessToken: "<%= current_community.theme.mapbox_token %>",
+  container: "placeMap", // container ID
+  center: coordinates, // starting position [lng, lat]
+  hash: false,
+  zoom: 3, // starting zoom
+  style: "<%= current_community.theme.mapbox_style %>", // style URL or style object
+  cooperativeGestures: true
+});
+
+const marker = new mapboxgl.Marker()
+  .setLngLat(coordinates)
+  .addTo(placeMap);
+
+// sync values when the map moves
+placeMap.on('move', () => {
+  let { lng, lat } = placeMap.getCenter();
+  placeLongInput.value = lng.toFixed(5);
+  placeLatInput.value = lat.toFixed(5);
+  marker.setLngLat({lng, lat});
+});
+
+// sync values when input is edited
+placeLongInput.addEventListener("change", (e) => {
+  let { lat } = placeMap.getCenter();
+  placeMap.setCenter({lng: e.target.value, lat: lat});
+});
+
+placeLatInput.addEventListener("change", (e) => {
+  let { lng } = placeMap.getCenter();
+  placeMap.setCenter({lng: lng, lat: e.target.value});
+});
+</script>


### PR DESCRIPTION
Closes https://github.com/Terrastories/terrastories/issues/805

This is a very similar implementation as the one for [themes](https://github.com/Terrastories/terrastories/blob/bb0784bd162dc2095b75afb7d01f0841ee0dadb4/rails/app/views/dashboard/themes/edit.html.erb#L163) (using the same 2 column CSS and set of event listeners), and includes functionality like https://github.com/Terrastories/terrastories/pull/921 as well.

![terrastories](https://github.com/Terrastories/terrastories/assets/217050/642ef59c-075e-4fbc-ae5e-35d0a2ebdf5e)

I verified this works offline as well, except we need to merge https://github.com/Terrastories/terrastories/pull/920 to fix the CSS issue.

I also verified it works for both Places #new and #edit (they share the _form partial)

As the issue mentioned, I locked the marker to the center of the map
instead of making it independently draggable. One of the consequences of
this is that it's a bit weird to set a point to one of the latitude
extremes (i.e. -90 or 90). Even editing this manually will get the value
reset to the center of the current map viewport depending on the zoom
level.

![boundaries](https://github.com/Terrastories/terrastories/assets/217050/78018fd9-fa4f-4257-812e-6dcc774b77c8)
