### PR TITLE
Add mapbox-gl back to react stylesheet

### DIFF
--- a/rails/app/assets/stylesheets/react.sass.scss
+++ b/rails/app/assets/stylesheets/react.sass.scss
@@ -1,2 +1,4 @@
+@import 'mapbox-gl/dist/mapbox-gl';
+
 @import 'core/core';
 @import 'components/components';


### PR DESCRIPTION
This PR fixes an issue where the mapbox-gl stylesheet was no longer being accessed by React, resulting in unstyled popups (among other things, probably).

Before:

![image](https://github.com/Terrastories/terrastories/assets/31662219/4efe24b3-761d-45ca-9d8d-4c86a7f2ae67)


After:

![image](https://github.com/Terrastories/terrastories/assets/31662219/22187980-82da-4dbc-b3ca-58916e7d718a)
