### PR TITLE
feat: wrap story description lines

### DIFF
--- a/rails/app/assets/stylesheets/components/card.scss
+++ b/rails/app/assets/stylesheets/components/card.scss
@@ -130,6 +130,10 @@ $el-shadow: 0 1px 4px $lighter-gray;
     flex: 5 0 0;
     .container {
       padding-bottom: 3rem;
+
+      .description {
+        white-space: pre-wrap;
+      }
     }
     .speakers {
       img {

--- a/rails/app/assets/stylesheets/core/_typography.scss
+++ b/rails/app/assets/stylesheets/core/_typography.scss
@@ -51,3 +51,7 @@ p {
 .small {
   font-size: .9rem;
 }
+
+.render-lines {
+  white-space: pre-wrap;
+}

--- a/rails/app/javascript/components/Story.jsx
+++ b/rails/app/javascript/components/Story.jsx
@@ -50,7 +50,7 @@ const Story = props => {
             {story.title}
             {story.permission_level === "restricted" && " 🔒"}
           </h6>
-          <p>{story.desc}</p>
+          <p className="description">{story.desc}</p>
           {
             story.media &&
             story.media.map(file => (

--- a/rails/app/views/dashboard/stories/show.html.erb
+++ b/rails/app/views/dashboard/stories/show.html.erb
@@ -83,7 +83,7 @@
   </div>
 
   <div class="two-columns-left">
-    <p><%= @story.desc %></p>
+    <p class="render-lines"><%= @story.desc %></p>
 
     <% @story.media.each do |media| %>
       <p class="media">


### PR DESCRIPTION
When new lines are added to the description (e.g. Shift+Enter), ensure those are appropriately rendered when displaying the description in the story view.

This is done using pure css with white-space render specifications. While there is interest in adding the ability for additional rendering tags (such as links), this is an easy-win with no security risks (injection). I purposely created two separate classnames for the styles in React vs CMS since they are bundled differently and this is likely just a stop-gap toward a more robust implementation.

**In Dashboard**
<img width="642" alt="image" src="https://github.com/Terrastories/terrastories/assets/2660801/345a7a99-944d-46cb-8b70-64ea6ba0a96f">

**In Map**
<img width="470" alt="image" src="https://github.com/Terrastories/terrastories/assets/2660801/424c557c-3bc1-4acf-84d1-00c51d320211">
