### PR TITLE
fix: Filter out Places with `null` coords in JSON builder

### DIFF
--- a/rails/app/views/home/_home.json.jbuilder
+++ b/rails/app/views/home/_home.json.jbuilder
@@ -1,7 +1,14 @@
-json.stories stories do |story|
+filtered_stories = stories.reject do |story|
+  places_with_valid_coords = story.places.reject { |place| place.lat.nil? || place.long.nil? }
+  places_with_valid_coords.empty?
+end
+
+json.stories filtered_stories do |story|
   json.extract! story, :title, :desc, :id, :created_at
-  json.points story.places.map(&:point_geojson)
-  json.places story.places
+  places_with_valid_coords = story.places.reject { |place| place.lat.nil? || place.long.nil? }
+  json.points places_with_valid_coords.map(&:point_geojson)
+  json.places places_with_valid_coords
+
   json.language story.language
   json.media story.media do |media|
     json.id media.id


### PR DESCRIPTION
This PR modifies the JSON builder logic to filter out any Places with null coordinates (`lat` `long`), and any Stories that _only_ have Places with null coordinates.

This is a validation on the front end to prevent any Places with null coordinates from rendering. Although we are currently requiring lat/long fields when creating a new Place in the CMS, the Importer permits the user to upload Places without lat/longs hence introducing a bug where Places without lat/long are passed on to React. 

This bug doesn't crash the app as Mapbox renders null coords as `(0,0)` but a more desirable handing of this would be to not use these Places on the front end at all, until the user has set coords for them.

In the future we need to rework the Importer as a whole, but that's a whole 'nother epic.