### PR TITLE
[WIP] fix: Add scope to Place & Story Model to filter out null coords

### DIFF
--- a/rails/app/controllers/api/stories_controller.rb
+++ b/rails/app/controllers/api/stories_controller.rb
@@ -5,6 +5,7 @@ module Api
       @stories = community.stories.joins(:places, :speakers).where(permission_level: :anonymous).preload(:places, :speakers)
 
       # Filters
+      @stories = @stories.with_valid_places
       @stories = @stories.where(places: {id: story_params[:places]}) if story_params[:places]
       @stories = @stories.where(places: {region: story_params[:region]}) if story_params[:region]
       @stories = @stories.where(places: {type_of_place: story_params[:type_of_place]}) if story_params[:type_of_place]

--- a/rails/app/models/community.rb
+++ b/rails/app/models/community.rb
@@ -39,11 +39,11 @@ class Community < ApplicationRecord
 
   def filters(permission_level = :anonymous)
     [
-      places.joins(:stories).where(stories: {permission_level: permission_level}).distinct.map { |p| {label: p.name, value: p.id, category: :places } },
-      places.joins(:stories).where(stories: {permission_level: permission_level}).pluck(:region).uniq.reject(&:blank?).map { |r| {label: r, value: r, category: :region } },
-      places.joins(:stories).where(stories: {permission_level: permission_level}).pluck(:type_of_place).uniq.reject(&:blank?).map { |r| {label: r, value: r, category: :type_of_place } },
-      stories.where(stories: {permission_level: permission_level}).pluck(:topic).uniq.reject(&:blank?).map { |r| {label: r, value: r, category: :topic } },
-      stories.where(stories: {permission_level: permission_level}).pluck(:language).uniq.reject(&:blank?).map { |r| {label: r, value: r, category: :language } },
+      places.with_valid_coordinates.joins(:stories).where(stories: {permission_level: permission_level}).distinct.map { |p| {label: p.name, value: p.id, category: :places } },
+      places.with_valid_coordinates.joins(:stories).where(stories: {permission_level: permission_level}).pluck(:region).uniq.reject(&:blank?).map { |r| {label: r, value: r, category: :region } },
+      places.with_valid_coordinates.joins(:stories).where(stories: {permission_level: permission_level}).pluck(:type_of_place).uniq.reject(&:blank?).map { |r| {label: r, value: r, category: :type_of_place } },
+      stories.with_valid_places.where(stories: {permission_level: permission_level}).pluck(:topic).uniq.reject(&:blank?).map { |r| {label: r, value: r, category: :topic } },
+      stories.with_valid_places.where(stories: {permission_level: permission_level}).pluck(:language).uniq.reject(&:blank?).map { |r| {label: r, value: r, category: :language } },
       speakers.joins(:stories).where(stories: {permission_level: permission_level}).distinct.map { |s| {value: s.id, label: s.name, category: :speakers } },
       speakers.joins(:stories).where(stories: {permission_level: permission_level}).pluck(:speaker_community).uniq.reject(&:blank?).map { |r| {label: r, value: r, category: :speaker_community } }
     ].flatten

--- a/rails/app/models/community.rb
+++ b/rails/app/models/community.rb
@@ -39,7 +39,7 @@ class Community < ApplicationRecord
 
   def filters(permission_level = :anonymous, valid_places = Place.with_valid_coordinates, valid_stories = Story.with_valid_places)
     [
-      valid_places.joins(:stories).where(stories: {permivalid_placesssion_level: permission_level}).distinct.map { |p| {label: p.name, value: p.id, category: :places } },
+      valid_places.joins(:stories).where(stories: {permission_level: permission_level}).distinct.map { |p| {label: p.name, value: p.id, category: :places } },
       valid_places.joins(:stories).where(stories: {permission_level: permission_level}).pluck(:region).uniq.reject(&:blank?).map { |r| {label: r, value: r, category: :region } },
       valid_places.joins(:stories).where(stories: {permission_level: permission_level}).pluck(:type_of_place).uniq.reject(&:blank?).map { |r| {label: r, value: r, category: :type_of_place } },
       valid_stories.where(stories: {permission_level: permission_level}).pluck(:topic).uniq.reject(&:blank?).map { |r| {label: r, value: r, category: :topic } },

--- a/rails/app/models/community.rb
+++ b/rails/app/models/community.rb
@@ -37,13 +37,13 @@ class Community < ApplicationRecord
     super(value)
   end
 
-  def filters(permission_level = :anonymous)
+  def filters(permission_level = :anonymous, valid_places = Place.with_valid_coordinates, valid_stories = Story.with_valid_places)
     [
-      places.with_valid_coordinates.joins(:stories).where(stories: {permission_level: permission_level}).distinct.map { |p| {label: p.name, value: p.id, category: :places } },
-      places.with_valid_coordinates.joins(:stories).where(stories: {permission_level: permission_level}).pluck(:region).uniq.reject(&:blank?).map { |r| {label: r, value: r, category: :region } },
-      places.with_valid_coordinates.joins(:stories).where(stories: {permission_level: permission_level}).pluck(:type_of_place).uniq.reject(&:blank?).map { |r| {label: r, value: r, category: :type_of_place } },
-      stories.with_valid_places.where(stories: {permission_level: permission_level}).pluck(:topic).uniq.reject(&:blank?).map { |r| {label: r, value: r, category: :topic } },
-      stories.with_valid_places.where(stories: {permission_level: permission_level}).pluck(:language).uniq.reject(&:blank?).map { |r| {label: r, value: r, category: :language } },
+      valid_places.joins(:stories).where(stories: {permivalid_placesssion_level: permission_level}).distinct.map { |p| {label: p.name, value: p.id, category: :places } },
+      valid_places.joins(:stories).where(stories: {permission_level: permission_level}).pluck(:region).uniq.reject(&:blank?).map { |r| {label: r, value: r, category: :region } },
+      valid_places.joins(:stories).where(stories: {permission_level: permission_level}).pluck(:type_of_place).uniq.reject(&:blank?).map { |r| {label: r, value: r, category: :type_of_place } },
+      valid_stories.where(stories: {permission_level: permission_level}).pluck(:topic).uniq.reject(&:blank?).map { |r| {label: r, value: r, category: :topic } },
+      valid_stories.where(stories: {permission_level: permission_level}).pluck(:language).uniq.reject(&:blank?).map { |r| {label: r, value: r, category: :language } },
       speakers.joins(:stories).where(stories: {permission_level: permission_level}).distinct.map { |s| {value: s.id, label: s.name, category: :speakers } },
       speakers.joins(:stories).where(stories: {permission_level: permission_level}).pluck(:speaker_community).uniq.reject(&:blank?).map { |r| {label: r, value: r, category: :speaker_community } }
     ].flatten

--- a/rails/app/models/place.rb
+++ b/rails/app/models/place.rb
@@ -14,6 +14,10 @@ class Place < ApplicationRecord
 
   attr_reader :point_geojson
 
+  scope :with_valid_coordinates, -> do
+    where.not(lat: nil, long: nil)
+  end
+
   def photo_url(full_url: false, thumbnail: false)
     if photo.attached?
       if full_url

--- a/rails/app/models/story.rb
+++ b/rails/app/models/story.rb
@@ -15,6 +15,10 @@ class Story < ApplicationRecord
   validates :place_ids, presence: true
   validates :media, blob: { content_type: ['image/png', 'image/jpg', 'image/jpeg', 'video/mpeg', 'video/mp4', 'video/quicktime', 'video/webm', 'audio/mpeg', 'audio/wav', 'audio/mp4', 'audio/m4a', 'audio/x-m4a', 'audio/x-aac', 'audio/x-flac'] }
 
+  scope :with_valid_places, -> do
+    joins(:places).where.not(places: { lat: nil, long: nil })
+  end
+
   def media_types
     media.flat_map { |media| media.content_type.split('/')[0] }.uniq
   end

--- a/rails/app/views/api/communities/show.json.jbuilder
+++ b/rails/app/views/api/communities/show.json.jbuilder
@@ -13,7 +13,7 @@ json.details do
 end
 
 # Initial Map Configuration
-stories = @community.stories.preload(:places).where(permission_level: :anonymous)
+stories = @community.stories.preload(:places).where(permission_level: :anonymous).with_valid_places
 json.storiesCount stories.size
 json.points stories.flat_map(&:public_points).uniq
 

--- a/rails/app/views/home/_home.json.jbuilder
+++ b/rails/app/views/home/_home.json.jbuilder
@@ -1,7 +1,14 @@
-json.stories stories do |story|
+filtered_stories = stories.reject do |story|
+  places_with_valid_coords = story.places.reject { |place| place.lat.nil? || place.long.nil? }
+  places_with_valid_coords.empty?
+end
+
+json.stories filtered_stories do |story|
   json.extract! story, :title, :desc, :id, :created_at
-  json.points story.places.map(&:point_geojson)
-  json.places story.places
+  places_with_valid_coords = story.places.reject { |place| place.lat.nil? || place.long.nil? }
+  json.points places_with_valid_coords.map(&:point_geojson)
+  json.places places_with_valid_coords
+
   json.language story.language
   json.media story.media do |media|
     json.id media.id

--- a/rails/app/views/home/_home.json.jbuilder
+++ b/rails/app/views/home/_home.json.jbuilder
@@ -1,14 +1,7 @@
-filtered_stories = stories.reject do |story|
-  places_with_valid_coords = story.places.reject { |place| place.lat.nil? || place.long.nil? }
-  places_with_valid_coords.empty?
-end
-
-json.stories filtered_stories do |story|
+json.stories stories.with_valid_places do |story|
   json.extract! story, :title, :desc, :id, :created_at
-  places_with_valid_coords = story.places.reject { |place| place.lat.nil? || place.long.nil? }
-  json.points places_with_valid_coords.map(&:point_geojson)
-  json.places places_with_valid_coords
-
+  json.points story.places.map(&:point_geojson)
+  json.places story.places
   json.language story.language
   json.media story.media do |media|
     json.id media.id

--- a/rails/spec/factories/community_factory.rb
+++ b/rails/spec/factories/community_factory.rb
@@ -3,10 +3,6 @@ FactoryBot.define do
     name { "Matawai "}
     locale { "mat" }
     country { "Suriname" }
-
-    factory :public_community do
-      public { true }
-      slug { }
-    end
+    slug { name.gsub(/\s+/, "").underscore }
   end
 end

--- a/rails/spec/models/community_spec.rb
+++ b/rails/spec/models/community_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Community, type: :model do
     end
 
     it "requires a slug when community is marked as public" do
+      community.slug = nil
       community.public = true
       expect(community).not_to be_valid
       expect(community.errors).to include(:slug)

--- a/rails/spec/requests/api/public_communities_spec.rb
+++ b/rails/spec/requests/api/public_communities_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe "Public Communities Endpoint", type: :request do
-  let!(:public_community) { FactoryBot.create(:public_community, name: "Cool Community") }
+  let!(:public_community) { FactoryBot.create(:community, public: true, name: "Cool Community") }
   let!(:community) { FactoryBot.create(:community, name: "Private Community") }
 
   def json_response

--- a/rails/spec/requests/api/public_community_spec.rb
+++ b/rails/spec/requests/api/public_community_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe "Public Community (show) Endpoint", type: :request do
-  let!(:public_community) { FactoryBot.create(:public_community, name: "Cool Community") }
+  let!(:public_community) { FactoryBot.create(:community, public: true, name: "Cool Community") }
 
   def json_response
     JSON.parse(response.body)
@@ -13,7 +13,7 @@ RSpec.describe "Public Community (show) Endpoint", type: :request do
     expect(response).to have_http_status(:not_found)
   end
 
-  it "returns a community's public details" do
+  it "returns an array of public communities" do
     get "/api/communities/cool_community"
 
     expect(json_response).to include(
@@ -44,7 +44,11 @@ RSpec.describe "Public Community (show) Endpoint", type: :request do
     it "includes community filter categories for landing panel" do
       get "/api/communities/cool_community"
 
-      expect(json_response["categories"]).to contain_exactly(*Community::FILTERABLE_ATTRIBUTES)
+      expect(json_response["categories"]).to contain_exactly(
+        *Community::FILTERABLE_ATTRIBUTES.map { |cat|
+          {"label" => I18n.t(cat), "value" => cat}
+        }
+      )
     end
 
     it "includes community map config" do

--- a/rails/spec/requests/api/public_place_spec.rb
+++ b/rails/spec/requests/api/public_place_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe "Public Place Endpoint", type: :request do
-  let!(:community) { FactoryBot.create(:public_community, name: "ATLAM Testing", slug: "atlam") }
+  let!(:community) { FactoryBot.create(:community, public: true, name: "ATALM Testing", slug: "atalm") }
   let!(:place) { FactoryBot.create(:place_with_stories, story_count: 2, community: community, id: 123) }
   let!(:public_story) do
     FactoryBot.create(
@@ -36,13 +36,13 @@ RSpec.describe "Public Place Endpoint", type: :request do
   end
 
   it "returns a 404 not found if place is not found" do
-    get "/api/communities/atlam/places/unknown"
+    get "/api/communities/atalm/places/unknown"
 
     expect(response).to have_http_status(:not_found)
   end
 
-  it "returns place details" do
-    get "/api/communities/atlam/places/123"
+  it "returns an array of public communities" do
+    get "/api/communities/atalm/places/123"
 
     expect(json_response.keys).to contain_exactly(
       "id",
@@ -56,8 +56,8 @@ RSpec.describe "Public Place Endpoint", type: :request do
     )
   end
 
-  it "includes the places public stories" do
-    get "/api/communities/atlam/places/123"
+  it "includes the places stories" do
+    get "/api/communities/atalm/places/123"
 
     expect(json_response["stories"].length).to eq(1)
     expect(json_response["stories"].first).to include(

--- a/rails/spec/requests/api/public_stories_spec.rb
+++ b/rails/spec/requests/api/public_stories_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "Public Stories Endpoint", type: :request do
-  let!(:community) { FactoryBot.create(:public_community, name: "Cool Community") }
+  let!(:community) { FactoryBot.create(:community, public: true, name: "Cool Community") }
 
   def json_response
     JSON.parse(response.body)

--- a/rails/spec/requests/api/public_story_spec.rb
+++ b/rails/spec/requests/api/public_story_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "Public Story Detail Endpoint", type: :request do
-  let!(:community) { FactoryBot.create(:public_community, name: "Cool Community") }
+  let!(:community) { FactoryBot.create(:community, public: true, name: "Cool Community") }
   let!(:place_1) { create(:place, community: community, region: "the internet") }
   let!(:place_2) { create(:place, community: community, type_of_place: "online") }
   let!(:speaker_1) { create(:speaker, community: community) }
@@ -31,7 +31,7 @@ RSpec.describe "Public Story Detail Endpoint", type: :request do
   end
 
   it "returns a 404 when community is not public" do
-    private_community = FactoryBot.create(:community, slug: "something")
+    private_community = FactoryBot.create(:community)
 
     get "/api/communities/#{private_community.slug}/stories/123"
 


### PR DESCRIPTION
This draft PR adds a scope to the Place and Story Models to permit filtering out any places that have null coordinates (primarily for the front end of TS Main and Explore).

Although we are currently requiring lat/long fields when creating a new Place in the CMS, the Importer currently permits the user to upload Places without lat/longs, hence introducing a bug where Places without lat/long are passed on to React. 

In the future we need to rework the Importer as a whole, but that's a whole 'nother epic.