### PR TITLE
Chore: Make media its own model

### DIFF
--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -49,7 +49,7 @@ gem 'devise-i18n', '~> 1.11.0'
 gem 'aws-sdk-s3', '~> 1.119.0'
 
 # ActiveStorage Validation
-gem 'activestorage-validator', '~> 0.2.0'
+gem 'active_storage_validations', '~> 1.0'
 
 # Enable Webpack for javascript application code
 gem 'webpacker', '~> 5.0'

--- a/rails/Gemfile.lock
+++ b/rails/Gemfile.lock
@@ -39,6 +39,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_storage_validations (1.0.4)
+      activejob (>= 5.2.0)
+      activemodel (>= 5.2.0)
+      activestorage (>= 5.2.0)
+      activesupport (>= 5.2.0)
     activejob (6.1.7.4)
       activesupport (= 6.1.7.4)
       globalid (>= 0.3.6)
@@ -54,8 +59,6 @@ GEM
       activesupport (= 6.1.7.4)
       marcel (~> 1.0)
       mini_mime (>= 1.1.0)
-    activestorage-validator (0.2.2)
-      rails (>= 6.0.4.1)
     activesupport (6.1.7.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
@@ -339,7 +342,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activestorage-validator (~> 0.2.0)
+  active_storage_validations (~> 1.0)
   annotate
   aws-sdk-s3 (~> 1.119.0)
   better_errors

--- a/rails/app/controllers/dashboard/stories_controller.rb
+++ b/rails/app/controllers/dashboard/stories_controller.rb
@@ -21,9 +21,12 @@ module Dashboard
 
     def create
       authorize Story
-      @story = community_stories.new(story_params)
+      @story = community_stories.new(story_params.except(:media))
 
       if @story.save
+        story_params[:media].each do |media|
+          m = @story.media.create(media: media)
+        end
         redirect_to @story
       else
         render :new
@@ -41,7 +44,11 @@ module Dashboard
     def update
       @story = authorize community_stories.find(params[:id])
 
-      if @story.update(story_params)
+      if @story.update(story_params.except(:media))
+        story_params[:media].each do |media|
+          m = @story.media.create(media: media)
+        end
+
         redirect_to @story
       else
         render :edit
@@ -59,8 +66,8 @@ module Dashboard
     def delete_media
       @story = authorize community_stories.find(params[:story_id])
 
-      media_blob = @story.media.blobs.find_signed(params[:id])
-      media_blob.attachments.each(&:purge)
+      media = @story.media.find(params[:id])
+      media.destroy
 
       head :ok
     end

--- a/rails/app/models/community.rb
+++ b/rails/app/models/community.rb
@@ -14,8 +14,8 @@ class Community < ApplicationRecord
 
   accepts_nested_attributes_for :users, limit: 1
 
-  validates :background_img, blob: { content_type: ['image/png', 'image/jpg', 'image/jpeg'] }
-  validates :sponsor_logos, blob: { content_type: ['image/png', 'image/jpg', 'image/jpeg'], size_range: 1..5.megabytes }
+  validates :background_img, content_type: ['image/png', 'image/jpg', 'image/jpeg']
+  validates :sponsor_logos, content_type: ['image/png', 'image/jpg', 'image/jpeg'], size: { between: 1..5.megabytes }
 
   validates :slug, presence: true, if: -> { self.public? }
 

--- a/rails/app/models/community.rb
+++ b/rails/app/models/community.rb
@@ -14,8 +14,8 @@ class Community < ApplicationRecord
 
   accepts_nested_attributes_for :users, limit: 1
 
-  validates :background_img, content_type: ['image/png', 'image/jpg', 'image/jpeg']
-  validates :sponsor_logos, content_type: ['image/png', 'image/jpg', 'image/jpeg'], size: { between: 1..5.megabytes }
+  validates :background_img, content_type: [:png, :jpeg, 'image/jpg'], size: { less_than_or_equal_to: 5.megabytes }
+  validates :sponsor_logos, content_type: [:png, :jpeg, 'image/jpg'], size: { less_than_or_equal_to: 5.megabytes }
 
   validates :slug, presence: true, if: -> { self.public? }
 

--- a/rails/app/models/media.rb
+++ b/rails/app/models/media.rb
@@ -1,4 +1,4 @@
-class Medium < ApplicationRecord
+class Media < ApplicationRecord
   self.table_name = "media"
 
   belongs_to :story

--- a/rails/app/models/medium.rb
+++ b/rails/app/models/medium.rb
@@ -21,7 +21,8 @@ class Medium < ApplicationRecord
       # audio types
       :mp3, :aac, :flac, :mp4a, :wav,
       'audio/wav', 'audio/m4a', 'audio/x-m4a', 'audio/x-aac', 'audio/x-flac',
-    ]
+    ],
+    size: { less_than_or_equal_to: 200.megabytes }
 
   delegate :content_type, :blob_id, :blob, to: :media
 end

--- a/rails/app/models/medium.rb
+++ b/rails/app/models/medium.rb
@@ -3,7 +3,11 @@ class Medium < ApplicationRecord
 
   belongs_to :story
 
-  has_one_attached :media
+  has_one_attached :media do
+    def blob_id
+      blob.id
+    end
+  end
 
   validates :media,
     attached: true,
@@ -18,6 +22,8 @@ class Medium < ApplicationRecord
       :mp3, :aac, :flac, :mp4a, :wav,
       'audio/wav', 'audio/m4a', 'audio/x-m4a', 'audio/x-aac', 'audio/x-flac',
     ]
+
+  delegate :content_type, :blob_id, :blob, to: :media
 end
 
 # == Schema Information

--- a/rails/app/models/medium.rb
+++ b/rails/app/models/medium.rb
@@ -1,0 +1,35 @@
+class Medium < ApplicationRecord
+  self.table_name = "media"
+
+  belongs_to :story
+
+  has_one_attached :media
+
+  validates :media,
+    attached: true,
+    # Symbol Content Types must map in Marcel::EXTENSIONS
+    # otherwise, use string for full mime type.
+    content_type: [
+      # image types
+      :png, :jpeg, :svg, 'image/jpg',
+      # video types
+      :mpeg, :mp4, :mov, :webm,
+      # audio types
+      :mp3, :aac, :flac, :mp4a, :wav,
+      'audio/wav', 'audio/m4a', 'audio/x-m4a', 'audio/x-aac', 'audio/x-flac',
+    ]
+end
+
+# == Schema Information
+#
+# Table name: media
+#
+#  id         :bigint           not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  story_id   :bigint
+#
+# Indexes
+#
+#  index_media_on_story_id  (story_id)
+#

--- a/rails/app/models/place.rb
+++ b/rails/app/models/place.rb
@@ -6,8 +6,8 @@ class Place < ApplicationRecord
   has_one_attached :photo
   has_one_attached :name_audio
   validates :name, presence: true
-  validates :photo, blob: { content_type: ['image/png', 'image/jpg', 'image/jpeg'] }
-  validates :name_audio, blob: { content_type: ['audio/mpeg', 'audio/wav', 'audio/mp4', 'audio/m4a', 'audio/x-m4a', 'audio/x-aac', 'audio/x-flac'] }
+  validates :photo, content_type: ['image/png', 'image/jpg', 'image/jpeg']
+  validates :name_audio, content_type: ['audio/mpeg', 'audio/wav', 'audio/mp4', 'audio/m4a', 'audio/x-m4a', 'audio/x-aac', 'audio/x-flac']
   validates :lat, numericality: { greater_than_or_equal_to:  -90, less_than_or_equal_to:  90, message: :invalid_latitude }, allow_blank: true
   validates :long, numericality: { greater_than_or_equal_to: -180, less_than_or_equal_to: 180, message: :invalid_longitude}, allow_blank: true
   has_many :interview_stories, class_name: "Story", foreign_key: "interview_location_id"

--- a/rails/app/models/place.rb
+++ b/rails/app/models/place.rb
@@ -6,8 +6,13 @@ class Place < ApplicationRecord
   has_one_attached :photo
   has_one_attached :name_audio
   validates :name, presence: true
-  validates :photo, content_type: ['image/png', 'image/jpg', 'image/jpeg']
-  validates :name_audio, content_type: ['audio/mpeg', 'audio/wav', 'audio/mp4', 'audio/m4a', 'audio/x-m4a', 'audio/x-aac', 'audio/x-flac']
+  validates :photo, content_type: [:png, 'image/jpg', :jpeg], size: { less_than_or_equal_to: 5.megabytes }
+  validates :name_audio,
+    content_type: [
+      :mp3, :aac, :flac, :mp4a, :wav,
+      'audio/wav', 'audio/m4a', 'audio/x-m4a', 'audio/x-aac', 'audio/x-flac',
+    ],
+    size: { less_than_or_equal_to: 10.megabytes }
   validates :lat, numericality: { greater_than_or_equal_to:  -90, less_than_or_equal_to:  90, message: :invalid_latitude }, allow_blank: true
   validates :long, numericality: { greater_than_or_equal_to: -180, less_than_or_equal_to: 180, message: :invalid_longitude}, allow_blank: true
   has_many :interview_stories, class_name: "Story", foreign_key: "interview_location_id"

--- a/rails/app/models/speaker.rb
+++ b/rails/app/models/speaker.rb
@@ -9,6 +9,8 @@ class Speaker < ApplicationRecord
 
   validates :name, presence: true
 
+  validates :photo, content_type: [:png, :jpeg, "image/jpg"], size: { less_than_or_equal_to: 5.megabytes }
+
   # photo
   def picture_url
     if photo.attached?

--- a/rails/app/models/story.rb
+++ b/rails/app/models/story.rb
@@ -16,6 +16,8 @@ class Story < ApplicationRecord
   validates :speaker_ids, presence: true
   validates :place_ids, presence: true
 
+  accepts_nested_attributes_for :media
+
   def media_types
     media.flat_map { |media| media.content_type.split('/')[0] }.uniq
   end

--- a/rails/app/models/story.rb
+++ b/rails/app/models/story.rb
@@ -19,7 +19,11 @@ class Story < ApplicationRecord
   accepts_nested_attributes_for :media
 
   def media_types
-    media.flat_map { |media| media.content_type.split('/')[0] }.uniq
+    media.flat_map do |m|
+      registry, kind = m.content_type.split('/')
+
+      registry == "application" ? kind : registry
+    end.uniq
   end
 
   def self.export_sample_csv

--- a/rails/app/models/story.rb
+++ b/rails/app/models/story.rb
@@ -3,7 +3,9 @@ class Story < ApplicationRecord
 
   has_many :speaker_stories, inverse_of: :story
   has_many :speakers, through: :speaker_stories
-  has_many_attached :media
+
+  has_many :media, inverse_of: :story
+
   has_and_belongs_to_many :places
   belongs_to :community, touch: true
   belongs_to :interview_location, class_name: "Place", foreign_key: "interview_location_id", optional: true
@@ -13,7 +15,6 @@ class Story < ApplicationRecord
   validates :title, presence: true
   validates :speaker_ids, presence: true
   validates :place_ids, presence: true
-  validates :media, blob: { content_type: ['image/png', 'image/jpg', 'image/jpeg', 'video/mpeg', 'video/mp4', 'video/quicktime', 'video/webm', 'audio/mpeg', 'audio/wav', 'audio/mp4', 'audio/m4a', 'audio/x-m4a', 'audio/x-aac', 'audio/x-flac'] }
 
   def media_types
     media.flat_map { |media| media.content_type.split('/')[0] }.uniq
@@ -53,9 +54,7 @@ class Story < ApplicationRecord
 
   EXCLUDE_ATTRIBUTES_FROM_IMPORT = %i[
     speaker_stories
-    media_attachments
     media_links
-    media_blobs
   ]
 end
 

--- a/rails/app/models/user.rb
+++ b/rails/app/models/user.rb
@@ -7,6 +7,7 @@ class User < ApplicationRecord
   belongs_to :community, optional: true, touch: true
   has_one_attached :photo
 
+  validates :photo, content_type: [:png, :jpeg, "image/jpg"], size: { less_than_or_equal_to: 5.megabytes }
   # Username is required for logging in with Devise. Email is optional.
   # Remove email_required? override if username changes to optional.
   validates :username, uniqueness: true, presence: true, format: {without: /\s/, message: :invalid_username_format}

--- a/rails/app/views/api/stories/show.json.jbuilder
+++ b/rails/app/views/api/stories/show.json.jbuilder
@@ -1,8 +1,8 @@
 json.(@story, :id, :title, :desc, :topic, :language)
 json.media @story.media do |media|
-  json.contentType media.blob.content_type
-  json.blob media.blob.id
-  json.url rails_blob_url(media)
+  json.contentType media.content_type
+  json.blob media.blob_id
+  json.url rails_blob_url(media.media)
 end
 json.speakers @story.speakers do |speaker|
   json.(speaker, :id, :name)

--- a/rails/app/views/dashboard/stories/_form.html.erb
+++ b/rails/app/views/dashboard/stories/_form.html.erb
@@ -21,50 +21,12 @@
 
   <% if @story.persisted? %>
   <div class="with-media-list">
-    <% if @story.media.attached? %>
+    <% if @story.media.any? %>
       <% @story.media.each do |media| %>
-        <% if media.image? %>
-          <span class="media-with-controls">
-            <% if media.variable? %>
-              <%= image_tag(media.variant(resize_to_limit: [150, 150])) %>
-            <% else %>
-              <%= image_tag(media, width: 150) %>
-            <% end %>
-            <%= link_to t("dashboard.actions.destroy"), story_delete_media_path(@story, media.signed_id), class: "delete-link", method: :delete, data: {confirm: t("dashboard.actions.confirm"), turbo_confirm: t("dashboard.actions.confirm"), turbo_method: :delete}, remote: true %>
-          </span>
-        <% elsif media.video? %>
-          <span class="media-with-controls">
-            <video
-              controls
-              disablePictureInPicture
-              controlsList="nodownload"
-              id="video-player-<%= media.blob.id %>"
-              poster="<%= url_for(media.preview(resize_to_limit:[150, 150])) if media.previewable? %>"
-            >
-              <source src="<%= url_for(media) %>"/>
-              <%= t("video_unsupported") %>
-            </video>
-            <%= link_to t("dashboard.actions.destroy"), story_delete_media_path(@story, media.signed_id), class: "delete-link", method: :delete, data: {confirm: t("dashboard.actions.confirm"), turbo_confirm: t("dashboard.actions.confirm"), turbo_method: :delete}, remote: true %>
-          </span>
-        <% elsif media.audio? %>
-          <span class="media-with-controls">
-            <audio id="audio-player-<%= media.blob.id %>"
-              controls
-              controlsList="nodownload"
-              ref="audio"
-            >
-              <source src="<%= url_for(media) %>" type="<%= media.blob.content_type %>" />
-            </audio>
-            <%= link_to t("dashboard.actions.destroy"), story_delete_media_path(@story, media.signed_id), class: "delete-link", method: :delete, data: {confirm: t("dashboard.actions.confirm"), turbo_confirm: t("dashboard.actions.confirm"), turbo_method: :delete}, remote: true %>
-          </span>
-        <% elsif media.previewable? %>
-          <span class="media-with-controls">
-            <%= image_tag(media.preview(resize_to_limit:[150, 150])) %>
-            <%= link_to t("dashboard.actions.destroy"), story_delete_media_path(@story, media.signed_id), class: "delete-link", method: :delete, data: {confirm: t("dashboard.actions.confirm"), turbo_confirm: t("dashboard.actions.confirm"), turbo_method: :delete}, remote: true %>
-        <% else %>
-          <%= media.filename %>
-          <%= link_to t("dashboard.actions.destroy"), story_delete_media_path(@story, media.signed_id), class: "delete-link", method: :delete, data: {confirm: t("dashboard.actions.confirm"), turbo_confirm: t("dashboard.actions.confirm"), turbo_method: :delete}, remote: true %>
-        <% end %>
+        <span class="media-with-controls">
+          <%= render partial: "media", locals: {media: media.media, size: 150} %>
+          <%= link_to t("dashboard.actions.destroy"), story_delete_media_path(@story, media.id), class: "delete-link", method: :delete, data: {confirm: t("dashboard.actions.confirm"), turbo_confirm: t("dashboard.actions.confirm"), turbo_method: :delete}, remote: true %>
+        </span>
       <% end %>
     <% end %>
   </div>

--- a/rails/app/views/dashboard/stories/_media.html.erb
+++ b/rails/app/views/dashboard/stories/_media.html.erb
@@ -1,0 +1,30 @@
+<% if media.image? %>
+  <% if media.variable? %>
+    <%= image_tag(media.variant(resize_to_limit: [size, size])) %>
+  <% else %>
+    <%= image_tag(media, width: size) %>
+  <% end %>
+<% elsif media.video? %>
+  <video
+    controls
+    disablePictureInPicture
+    controlsList="nodownload"
+    id="video-player-<%= media.blob.id %>"
+    poster="<%= url_for(media.preview(resize_to_limit:[nil, size])) if media.previewable? %>"
+  >
+    <source src="<%= url_for(media) %>"/>
+    <%= t("video_unsupported") %>
+  </video>
+<% elsif media.audio? %>
+  <audio id="audio-player-<%= media.blob.id %>"
+    controls
+    controlsList="nodownload"
+    ref="audio"
+  >
+    <source src="<%= url_for(media) %>" type="<%= media.blob.content_type %>" />
+  </audio>
+<% elsif media.previewable? %>
+  <%= image_tag(media.preview(resize_to_limit:[size, size])) %>
+<% else %>
+  <%= media.filename %>
+<% end %>

--- a/rails/app/views/dashboard/stories/show.html.erb
+++ b/rails/app/views/dashboard/stories/show.html.erb
@@ -87,36 +87,7 @@
 
     <% @story.media.each do |media| %>
       <p class="media">
-        <% if media.image? %>
-          <% if media.variable? %>
-            <%= image_tag(media.variant(resize_to_limit: [400, 400])) %>
-          <% else %>
-            <%= image_tag(media, width: 400) %>
-          <% end %>
-        <% elsif media.video? %>
-          <video
-            controls
-            disablePictureInPicture
-            controlsList="nodownload"
-            id="video-player-<%= media.blob.id %>"
-            poster="<%= url_for(media.preview(resize_to_limit:[400, 400])) if media.previewable? %>"
-          >
-            <source src="<%= url_for(media) %>"/>
-            <%= t("video_unsupported") %>
-          </video>
-        <% elsif media.audio? %>
-          <audio id="audio-player-<%= media.blob.id %>"
-            controls
-            controlsList="nodownload"
-            ref="audio"
-          >
-            <source src="<%= url_for(media) %>" type="<%= media.blob.content_type %>" />
-          </audio>
-        <% elsif media.previewable? %>
-            <%= image_tag(media.preview(resize_to_limit:[150, 150])) %>
-        <% else %>
-          <%= media.filename %>
-        <% end %>
+        <%= render partial: "media", locals: {media: media.media, size: 400} %>
       </p>
     <% end %>
   </div>

--- a/rails/app/views/home/_home.json.jbuilder
+++ b/rails/app/views/home/_home.json.jbuilder
@@ -4,8 +4,8 @@ json.stories stories do |story|
   json.places story.places
   json.language story.language
   json.media story.media do |media|
-    json.id media.id
-    json.url url_for(media)
+    json.id media.blob_id
+    json.url url_for(media.media)
     json.blob media.blob
   end
   json.speakers story.speakers do |speaker|

--- a/rails/config/initializers/cors.rb
+++ b/rails/config/initializers/cors.rb
@@ -2,5 +2,6 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
     origins ENV.fetch("CORS_ORIGINS", "").split(",").map { |origin| origin[0] == "\\" ? Regexp.new(origin) : origin }
     resource '/api/*', headers: :any, methods: [:get]
+    resource '/rails/active_storage/*', headers: :any, methods: [:get]
   end
 end

--- a/rails/config/initializers/inflections.rb
+++ b/rails/config/initializers/inflections.rb
@@ -3,12 +3,13 @@
 # Add new inflection rules using the following format. Inflections
 # are locale specific, and you may define rules for as many different
 # locales as you wish. All of these examples are active by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.plural /^(ox)$/i, '\1en'
-#   inflect.singular /^(ox)en/i, '\1'
-#   inflect.irregular 'person', 'people'
-#   inflect.uncountable %w( fish sheep )
-# end
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  # inflect.plural /^(ox)$/i, '\1en'
+  # inflect.singular /^(ox)en/i, '\1'
+  # inflect.irregular 'person', 'people'
+  # inflect.uncountable %w( fish sheep )
+  inflect.irregular 'media', 'media'
+end
 
 # These inflection rules are supported but not enabled by default:
 # ActiveSupport::Inflector.inflections(:en) do |inflect|

--- a/rails/config/initializers/new_framework_defaults_6_1.rb
+++ b/rails/config/initializers/new_framework_defaults_6_1.rb
@@ -48,10 +48,10 @@
 # Rails.application.config.action_view.form_with_generates_remote_forms = false
 
 # Set the default queue name for the analysis job to the queue adapter default.
-# Rails.application.config.active_storage.queues.analysis = nil
+Rails.application.config.active_storage.queues.analysis = nil
 
 # Set the default queue name for the purge job to the queue adapter default.
-# Rails.application.config.active_storage.queues.purge = nil
+Rails.application.config.active_storage.queues.purge = nil
 
 # Set the default queue name for the incineration job to the queue adapter default.
 # Rails.application.config.action_mailbox.queues.incineration = nil

--- a/rails/config/locales/en/models.en.yml
+++ b/rails/config/locales/en/models.en.yml
@@ -8,6 +8,28 @@ en:
       invalid_pitch: value should be 0 and 85
       invalid_bearing: value should be between -180 and 180
       invalid_username_format: cannot contain spaces
+      # START Active Storage Validations
+      content_type_invalid: "has an invalid content type"
+      file_size_out_of_range: "size %{file_size} is not between required range"
+      limit_out_of_range: "total number is out of range"
+      image_metadata_missing: "is not a valid image"
+      dimension_min_inclusion: "must be greater than or equal to %{width} x %{height} pixel."
+      dimension_max_inclusion: "must be less than or equal to %{width} x %{height} pixel."
+      dimension_width_inclusion: "width is not included between %{min} and %{max} pixel."
+      dimension_height_inclusion: "height is not included between %{min} and %{max} pixel."
+      dimension_width_greater_than_or_equal_to: "width must be greater than or equal to %{length} pixel."
+      dimension_height_greater_than_or_equal_to: "height must be greater than or equal to %{length} pixel."
+      dimension_width_less_than_or_equal_to: "width must be less than or equal to %{length} pixel."
+      dimension_height_less_than_or_equal_to: "height must be less than or equal to %{length} pixel."
+      dimension_width_equal_to: "width must be equal to %{length} pixel."
+      dimension_height_equal_to: "height must be equal to %{length} pixel."
+      aspect_ratio_not_square: "must be a square image"
+      aspect_ratio_not_portrait: "must be a portrait image"
+      aspect_ratio_not_landscape: "must be a landscape image"
+      aspect_ratio_is_not: "must have an aspect ratio of %{aspect_ratio}"
+      aspect_ratio_unknown: "has an unknown aspect ratio"
+      image_not_processable: "is not a valid image"
+      # END Active Storage Validations
   helpers:
     label:
       visibility: Visibility

--- a/rails/db/migrate/20230808133755_create_media_model.rb
+++ b/rails/db/migrate/20230808133755_create_media_model.rb
@@ -1,0 +1,9 @@
+class CreateMediaModel < ActiveRecord::Migration[6.1]
+  def change
+    create_table :media do |t|
+      t.belongs_to :story
+
+      t.timestamps
+    end
+  end
+end

--- a/rails/db/migrate/20230808135800_move_story_media_attachments_to_model.rb
+++ b/rails/db/migrate/20230808135800_move_story_media_attachments_to_model.rb
@@ -1,0 +1,20 @@
+class MoveStoryMediaAttachmentsToModel < ActiveRecord::Migration[6.1]
+  def up
+    ActiveStorage::Attachment.where(record_type: "Story").find_each do |att|
+      story = Story.find_by(id: att.record_id)
+      next if story.nil?
+
+      media = Medium.new(story_id: att.record_id)
+      media.save!(:validate => false)
+
+      att.update(record_type: "Medium", record_id: media.id)
+    end
+  end
+
+  def down
+    ActiveStorage::Attachment.where(record_type: "Medium").find_each do |att|
+      att.update(record_type: "Story", record_id: att.record.story_id)
+    end
+    Medium.delete_all
+  end
+end

--- a/rails/db/migrate/20230808135800_move_story_media_attachments_to_model.rb
+++ b/rails/db/migrate/20230808135800_move_story_media_attachments_to_model.rb
@@ -4,17 +4,17 @@ class MoveStoryMediaAttachmentsToModel < ActiveRecord::Migration[6.1]
       story = Story.find_by(id: att.record_id)
       next if story.nil?
 
-      media = Medium.new(story_id: att.record_id)
+      media = Media.new(story_id: att.record_id)
       media.save!(:validate => false)
 
-      att.update(record_type: "Medium", record_id: media.id)
+      att.update(record_type: "Media", record_id: media.id)
     end
   end
 
   def down
-    ActiveStorage::Attachment.where(record_type: "Medium").find_each do |att|
+    ActiveStorage::Attachment.where(record_type: "Media").find_each do |att|
       att.update(record_type: "Story", record_id: att.record.story_id)
     end
-    Medium.delete_all
+    Media.delete_all
   end
 end

--- a/rails/db/schema.rb
+++ b/rails/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_08_08_133755) do
+ActiveRecord::Schema.define(version: 2023_08_08_135800) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/rails/db/schema.rb
+++ b/rails/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_12_26_213911) do
+ActiveRecord::Schema.define(version: 2023_08_08_133755) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -91,6 +91,13 @@ ActiveRecord::Schema.define(version: 2022_12_26_213911) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true
+  end
+
+  create_table "media", force: :cascade do |t|
+    t.bigint "story_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["story_id"], name: "index_media_on_story_id"
   end
 
   create_table "media_links", force: :cascade do |t|

--- a/rails/spec/models/community_spec.rb
+++ b/rails/spec/models/community_spec.rb
@@ -3,6 +3,26 @@ require 'rails_helper'
 RSpec.describe Community, type: :model do
   let(:community) { FactoryBot.create(:community) }
 
+  describe "validations" do
+    it "validates content type size" do
+      is_expected.to validate_content_type_of(:background_img).allowing(
+        'image/png',
+        'image/jpg',
+        'image/jpeg',
+      )
+      is_expected.to validate_content_type_of(:sponsor_logos).allowing(
+        'image/png',
+        'image/jpg',
+        'image/jpeg',
+      )
+    end
+
+    it "validates file size" do
+      is_expected.to validate_size_of(:background_img).less_than_or_equal_to(5.megabytes)
+      is_expected.to validate_size_of(:sponsor_logos).less_than_or_equal_to(5.megabytes)
+    end
+  end
+
   describe "associations" do
     it "can add sponsor logo" do
       community.sponsor_logos.attach(io: File.open("./spec/fixtures/media/terrastories.png"), filename: 'file.pdf')

--- a/rails/spec/models/media_spec.rb
+++ b/rails/spec/models/media_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Medium, type: :model do
+RSpec.describe Media, type: :model do
   describe "associations" do
     it { is_expected.to belong_to(:story) }
   end

--- a/rails/spec/models/medium_spec.rb
+++ b/rails/spec/models/medium_spec.rb
@@ -37,5 +37,9 @@ RSpec.describe Medium, type: :model do
         'video/webm',
       )
     end
+
+    it "validates file size" do
+      is_expected.to validate_size_of(:media).less_than_or_equal_to(200.megabytes)
+    end
   end
 end

--- a/rails/spec/models/medium_spec.rb
+++ b/rails/spec/models/medium_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe Medium, type: :model do
+  describe "associations" do
+    it { is_expected.to belong_to(:story) }
+  end
+
+  describe "media validations" do
+    it { is_expected.to validate_attached_of(:media) }
+
+    it "validates image types" do
+      is_expected.to validate_content_type_of(:media).allowing(
+        'image/png',
+        'image/jpg',
+        'image/jpeg',
+        'image/svg+xml',
+      )
+    end
+
+    it "validates audio types" do
+      is_expected.to validate_content_type_of(:media).allowing(
+        'audio/mpeg',
+        'audio/wav',
+        'audio/mp4',
+        'audio/m4a',
+        'audio/x-m4a',
+        'audio/x-aac',
+        'audio/x-flac',
+      )
+    end
+
+    it "validates video types" do
+      is_expected.to validate_content_type_of(:media).allowing(
+        'video/mpeg',
+        'video/mp4',
+        'video/quicktime',
+        'video/webm',
+      )
+    end
+  end
+end

--- a/rails/spec/models/place_spec.rb
+++ b/rails/spec/models/place_spec.rb
@@ -1,6 +1,38 @@
 require 'rails_helper'
 
 RSpec.describe Place, type: :model do
+  describe "photo validations" do
+    it "validates content type size" do
+      is_expected.to validate_content_type_of(:photo).allowing(
+        'image/png',
+        'image/jpg',
+        'image/jpeg',
+      )
+    end
+
+    it "validates file size" do
+      is_expected.to validate_size_of(:photo).less_than_or_equal_to(5.megabytes)
+    end
+  end
+
+  describe "audio validations" do
+    it "validates content type size" do
+      is_expected.to validate_content_type_of(:name_audio).allowing(
+        'audio/mpeg',
+        'audio/wav',
+        'audio/mp4',
+        'audio/m4a',
+        'audio/x-m4a',
+        'audio/x-aac',
+        'audio/x-flac',
+      )
+    end
+
+    it "validates file size" do
+      is_expected.to validate_size_of(:name_audio).less_than_or_equal_to(10.megabytes)
+    end
+  end
+
   describe 'associations' do
     it { should have_and_belong_to_many :stories }
     it { should have_many :interview_stories }

--- a/rails/spec/models/speaker_spec.rb
+++ b/rails/spec/models/speaker_spec.rb
@@ -4,6 +4,20 @@ RSpec.describe Speaker, type: :model do
   let(:community) { create(:community) }
   let(:speaker) { build(:speaker, name: speaker_name, birthdate: speaker_birthdate) }
 
+  describe "validations" do
+    it "validates content type size" do
+      is_expected.to validate_content_type_of(:photo).allowing(
+        'image/png',
+        'image/jpg',
+        'image/jpeg',
+      )
+    end
+
+    it "validates file size" do
+      is_expected.to validate_size_of(:photo).less_than_or_equal_to(5.megabytes)
+    end
+  end
+
   describe 'attributes' do
     let(:speaker_name) { 'Oliver Twist' }
     let(:speaker_birthdate) { DateTime.new(1992) }

--- a/rails/spec/models/story_spec.rb
+++ b/rails/spec/models/story_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Story, type: :model do
 
   describe "#csv_headers" do
     it "defines importable CSV headers" do
-      expect(described_class.csv_headers).to eq(
+      expect(described_class.csv_headers).to match_array(
         %i[
           title
           desc
@@ -141,7 +141,7 @@ RSpec.describe Story, type: :model do
             mapped_headers
           )
         }.to change(described_class, :count).from(0).to(1)
-        expect(described_class.last.media).to be_attached
+        expect(described_class.last.media.size).to eq(1)
       end
 
       it "successfully imports stories with multiple medias" do

--- a/rails/spec/models/user_spec.rb
+++ b/rails/spec/models/user_spec.rb
@@ -1,6 +1,20 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
+  describe "validations" do
+    it "validates content type size" do
+      is_expected.to validate_content_type_of(:photo).allowing(
+        'image/png',
+        'image/jpg',
+        'image/jpeg',
+      )
+    end
+
+    it "validates file size" do
+      is_expected.to validate_size_of(:photo).less_than_or_equal_to(5.megabytes)
+    end
+  end
+
   describe 'ensuring a user always has a role set' do
     it 'has the correct default role as new user' do
       user = FactoryBot.create(:user)

--- a/rails/spec/rails_helper.rb
+++ b/rails/spec/rails_helper.rb
@@ -6,6 +6,7 @@ require_relative '../config/environment'
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
+require 'active_storage_validations/matchers'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
@@ -62,6 +63,9 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  # Active Storage Validations matcher helpers
+  config.include ActiveStorageValidations::Matchers
 end
 
 Shoulda::Matchers.configure do |config|


### PR DESCRIPTION
There are many features that are coming on the roadmap relating to Media attachments to a story. Since most of them will be significantly easier if all of the Media are encapsulated in its own model instead of a `has_many_attached` active storage solution, this PR is all of the chore work to create a standalone Medium model.

This PR:

- [x] Creates a new media table in the database.
- [x] A new Medium model in the app
- [x] Data migration to update the reference of `media` from Story to Media and the new Media to Story (this is reversible)
- [x] Updates all of the references and cleanup to add, remove, and display Media.
- [x] Ensures all references of Media correctly delegate through the Medium model.
- [x] Ensures import works as expected to attach Media attachments.

This PR does NOT:

- Add any of those coming soon roadmap features.
- Address any existing issues with displaying media attachments (if they didn't work before, they still don't work).