### PR TITLE
chore: truncate checkbox labels and increase column number to 3

### DIFF
--- a/rails/app/assets/stylesheets/cms/_forms.scss
+++ b/rails/app/assets/stylesheets/cms/_forms.scss
@@ -50,7 +50,7 @@ form.form {
   .checklist {
     display: grid;
     margin-bottom: 1rem;
-    grid-template-columns: 1rem max-content 1rem max-content 1 rem max-content;
+    grid-template-columns: 1rem max-content 1rem max-content 1rem max-content;
 
     input[type=checkbox] {
       margin: 2px;

--- a/rails/app/assets/stylesheets/cms/_forms.scss
+++ b/rails/app/assets/stylesheets/cms/_forms.scss
@@ -50,7 +50,7 @@ form.form {
   .checklist {
     display: grid;
     margin-bottom: 1rem;
-    grid-template-columns: 1rem max-content 1rem max-content;
+    grid-template-columns: 1rem max-content 1rem max-content 1 rem max-content;
 
     input[type=checkbox] {
       margin: 2px;
@@ -59,6 +59,10 @@ form.form {
     label {
       font-weight: normal;
       padding: 0 0.5rem 0 0.25rem;
+      max-width: 25rem;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
   }
 

--- a/rails/app/views/dashboard/places/_form.html.erb
+++ b/rails/app/views/dashboard/places/_form.html.erb
@@ -31,7 +31,10 @@
 
   <%= f.label :story_ids %>
   <div class="checklist">
-    <%= f.collection_check_boxes :story_ids, current_community.stories, :id, :title %>
+    <% current_community.stories.each do |story| %>
+      <%= f.check_box :story_ids, { multiple: true }, story.id, nil %>
+      <%= label_tag "story_ids_#{story.id}", story.title, title: story.title %>
+    <% end %>
   </div>
 
   <div class="two-columns">

--- a/rails/app/views/dashboard/speakers/_form.html.erb
+++ b/rails/app/views/dashboard/speakers/_form.html.erb
@@ -16,10 +16,14 @@
   <%= f.label :birthplace_id %>
   <%= f.collection_select :birthplace_id, current_community.places, :id, :name %>
 
-  <%= f.label :story_ids %>
-  <div class="checklist">
-  <%= f.collection_check_boxes :story_ids, current_community.stories, :id, :title %>
-  </div>
+<%= f.label :story_ids %>
+<div class="checklist">
+  <% current_community.stories.each do |story| %>
+    <%= f.check_box :story_ids, { multiple: true }, story.id, nil %>
+    <%= label_tag "story_ids_#{story.id}", story.title, title: story.title %>
+  <% end %>
+</div>
+
 
   <%= f.submit %>
 <% end %>

--- a/rails/app/views/dashboard/stories/_form.html.erb
+++ b/rails/app/views/dashboard/stories/_form.html.erb
@@ -72,12 +72,18 @@
 
   <%= f.label :speaker_ids, class: "required" %>
   <div class="checklist">
-    <%= f.collection_check_boxes :speaker_ids, current_community.speakers, :id, :name, required: true %>
+    <% current_community.speakers.each do |speaker| %>
+      <%= f.check_box :speaker_ids, { multiple: true, required: true }, speaker.id, nil %>
+      <%= label_tag "speaker_ids_#{speaker.id}", speaker.name, title: speaker.name %>
+    <% end %>
   </div>
 
   <%= f.label :place_ids, class: "required" %>
   <div class="checklist">
-    <%= f.collection_check_boxes :place_ids, current_community.places, :id, :name, required: true %>
+    <% current_community.places.each do |place| %>
+      <%= f.check_box :place_ids, { multiple: true, required: true }, place.id, nil %>
+      <%= label_tag "place_ids_#{place.id}", place.name, title: place.name %>
+    <% end %>
   </div>
 
   <%= f.label :interview_location_id %>


### PR DESCRIPTION
Currently, Stories/Places/Speakers checklists in the CMS edit form are showing the full title, which can be unwieldy with long titles:

![image](https://github.com/Terrastories/terrastories/assets/31662219/b65f91f6-750d-4ef3-902d-b8a4dddba8b5)

This PR truncates checkbox labels, and increases the total number of columns to 3 in the CMS edit forms. We can definitely do more to improve the form styling, but this is a quick fix for some online communities who are dealing with this.

Result:

![image](https://github.com/Terrastories/terrastories/assets/31662219/0f2a8805-7089-4ffc-9ccd-c8780e9d1760)
