### PR TITLE
fix: Add scope to Place & Story Model to filter out null coords (v2)

### DIFF
--- a/rails/app/controllers/api/stories_controller.rb
+++ b/rails/app/controllers/api/stories_controller.rb
@@ -2,7 +2,7 @@ module Api
   class StoriesController < BaseController
     def index
       community = Community.where(public: true).find_by!(slug: params[:community_id])
-      @stories = community.stories.with_valid_places.joins(:places, :speakers).where(permission_level: :anonymous).preload(:places, :speakers)
+      @stories = community.stories.joins(:places, :speakers).where(permission_level: :anonymous).preload(:places, :speakers)
 
       # Filters
       @stories = @stories.where(places: {id: story_params[:places]}) if story_params[:places]

--- a/rails/app/controllers/api/stories_controller.rb
+++ b/rails/app/controllers/api/stories_controller.rb
@@ -2,10 +2,9 @@ module Api
   class StoriesController < BaseController
     def index
       community = Community.where(public: true).find_by!(slug: params[:community_id])
-      @stories = community.stories.joins(:places, :speakers).where(permission_level: :anonymous).preload(:places, :speakers)
+      @stories = community.stories.with_valid_places.joins(:places, :speakers).where(permission_level: :anonymous).preload(:places, :speakers)
 
       # Filters
-      @stories = @stories.with_valid_places
       @stories = @stories.where(places: {id: story_params[:places]}) if story_params[:places]
       @stories = @stories.where(places: {region: story_params[:region]}) if story_params[:region]
       @stories = @stories.where(places: {type_of_place: story_params[:type_of_place]}) if story_params[:type_of_place]

--- a/rails/app/controllers/api/stories_controller.rb
+++ b/rails/app/controllers/api/stories_controller.rb
@@ -5,6 +5,7 @@ module Api
       @stories = community.stories.joins(:places, :speakers).where(permission_level: :anonymous).preload(:places, :speakers)
 
       # Filters
+      @stories = @stories.with_valid_places
       @stories = @stories.where(places: {id: story_params[:places]}) if story_params[:places]
       @stories = @stories.where(places: {region: story_params[:region]}) if story_params[:region]
       @stories = @stories.where(places: {type_of_place: story_params[:type_of_place]}) if story_params[:type_of_place]

--- a/rails/app/models/community.rb
+++ b/rails/app/models/community.rb
@@ -37,13 +37,13 @@ class Community < ApplicationRecord
     super(value)
   end
 
-  def filters(permission_level = :anonymous)
+  def filters(permission_level = :anonymous, valid_places = Place.with_valid_coordinates, valid_stories = Story.with_valid_places)
     [
-      places.joins(:stories).where(stories: {permission_level: permission_level}).distinct.map { |p| {label: p.name, value: p.id, category: :places } },
-      places.joins(:stories).where(stories: {permission_level: permission_level}).pluck(:region).uniq.reject(&:blank?).map { |r| {label: r, value: r, category: :region } },
-      places.joins(:stories).where(stories: {permission_level: permission_level}).pluck(:type_of_place).uniq.reject(&:blank?).map { |r| {label: r, value: r, category: :type_of_place } },
-      stories.where(stories: {permission_level: permission_level}).pluck(:topic).uniq.reject(&:blank?).map { |r| {label: r, value: r, category: :topic } },
-      stories.where(stories: {permission_level: permission_level}).pluck(:language).uniq.reject(&:blank?).map { |r| {label: r, value: r, category: :language } },
+      valid_places.joins(:stories).where(stories: {permission_level: permission_level}).distinct.map { |p| {label: p.name, value: p.id, category: :places } },
+      valid_places.joins(:stories).where(stories: {permission_level: permission_level}).pluck(:region).uniq.reject(&:blank?).map { |r| {label: r, value: r, category: :region } },
+      valid_places.joins(:stories).where(stories: {permission_level: permission_level}).pluck(:type_of_place).uniq.reject(&:blank?).map { |r| {label: r, value: r, category: :type_of_place } },
+      valid_stories.where(stories: {permission_level: permission_level}).pluck(:topic).uniq.reject(&:blank?).map { |r| {label: r, value: r, category: :topic } },
+      valid_stories.where(stories: {permission_level: permission_level}).pluck(:language).uniq.reject(&:blank?).map { |r| {label: r, value: r, category: :language } },
       speakers.joins(:stories).where(stories: {permission_level: permission_level}).distinct.map { |s| {value: s.id, label: s.name, category: :speakers } },
       speakers.joins(:stories).where(stories: {permission_level: permission_level}).pluck(:speaker_community).uniq.reject(&:blank?).map { |r| {label: r, value: r, category: :speaker_community } }
     ].flatten

--- a/rails/app/models/community.rb
+++ b/rails/app/models/community.rb
@@ -37,13 +37,13 @@ class Community < ApplicationRecord
     super(value)
   end
 
-  def filters(permission_level = :anonymous, valid_places = Place.with_valid_coordinates, valid_stories = Story.with_valid_places)
+  def filters(permission_level = :anonymous)
     [
-      valid_places.joins(:stories).where(stories: {permission_level: permission_level}).distinct.map { |p| {label: p.name, value: p.id, category: :places } },
-      valid_places.joins(:stories).where(stories: {permission_level: permission_level}).pluck(:region).uniq.reject(&:blank?).map { |r| {label: r, value: r, category: :region } },
-      valid_places.joins(:stories).where(stories: {permission_level: permission_level}).pluck(:type_of_place).uniq.reject(&:blank?).map { |r| {label: r, value: r, category: :type_of_place } },
-      valid_stories.where(stories: {permission_level: permission_level}).pluck(:topic).uniq.reject(&:blank?).map { |r| {label: r, value: r, category: :topic } },
-      valid_stories.where(stories: {permission_level: permission_level}).pluck(:language).uniq.reject(&:blank?).map { |r| {label: r, value: r, category: :language } },
+      places.joins(:stories).where(stories: {permission_level: permission_level}).distinct.map { |p| {label: p.name, value: p.id, category: :places } },
+      places.joins(:stories).where(stories: {permission_level: permission_level}).pluck(:region).uniq.reject(&:blank?).map { |r| {label: r, value: r, category: :region } },
+      places.joins(:stories).where(stories: {permission_level: permission_level}).pluck(:type_of_place).uniq.reject(&:blank?).map { |r| {label: r, value: r, category: :type_of_place } },
+      stories.where(stories: {permission_level: permission_level}).pluck(:topic).uniq.reject(&:blank?).map { |r| {label: r, value: r, category: :topic } },
+      stories.where(stories: {permission_level: permission_level}).pluck(:language).uniq.reject(&:blank?).map { |r| {label: r, value: r, category: :language } },
       speakers.joins(:stories).where(stories: {permission_level: permission_level}).distinct.map { |s| {value: s.id, label: s.name, category: :speakers } },
       speakers.joins(:stories).where(stories: {permission_level: permission_level}).pluck(:speaker_community).uniq.reject(&:blank?).map { |r| {label: r, value: r, category: :speaker_community } }
     ].flatten

--- a/rails/app/models/place.rb
+++ b/rails/app/models/place.rb
@@ -19,6 +19,10 @@ class Place < ApplicationRecord
 
   attr_reader :point_geojson
 
+  scope :with_valid_coordinates, -> do
+    where.not(lat: nil, long: nil)
+  end
+
   def photo_url(full_url: false, thumbnail: false)
     if photo.attached?
       if full_url

--- a/rails/app/models/story.rb
+++ b/rails/app/models/story.rb
@@ -6,7 +6,7 @@ class Story < ApplicationRecord
 
   has_many :media, inverse_of: :story
 
-  has_and_belongs_to_many :places
+  has_and_belongs_to_many :places, -> { with_valid_coordinates }
   belongs_to :community, touch: true
   belongs_to :interview_location, class_name: "Place", foreign_key: "interview_location_id", optional: true
   belongs_to :interviewer, class_name: "Speaker", foreign_key: "interviewer_id", optional: true
@@ -17,10 +17,6 @@ class Story < ApplicationRecord
   validates :place_ids, presence: true
 
   accepts_nested_attributes_for :media
-
-  scope :with_valid_places, -> do
-    joins(:places).where.not(places: { lat: nil, long: nil })
-  end
 
   def media_types
     media.flat_map do |m|

--- a/rails/app/models/story.rb
+++ b/rails/app/models/story.rb
@@ -18,6 +18,10 @@ class Story < ApplicationRecord
 
   accepts_nested_attributes_for :media
 
+  scope :with_valid_places, -> do
+    joins(:places).where.not(places: { lat: nil, long: nil })
+  end
+
   def media_types
     media.flat_map do |m|
       registry, kind = m.content_type.split('/')

--- a/rails/app/views/api/communities/show.json.jbuilder
+++ b/rails/app/views/api/communities/show.json.jbuilder
@@ -13,7 +13,7 @@ json.details do
 end
 
 # Initial Map Configuration
-stories = @community.stories.preload(:places).where(permission_level: :anonymous)
+stories = @community.stories.preload(:places).where(permission_level: :anonymous).with_valid_places
 json.storiesCount stories.size
 json.points stories.flat_map(&:public_points).uniq
 

--- a/rails/app/views/api/communities/show.json.jbuilder
+++ b/rails/app/views/api/communities/show.json.jbuilder
@@ -13,7 +13,7 @@ json.details do
 end
 
 # Initial Map Configuration
-stories = @community.stories.preload(:places).where(permission_level: :anonymous).with_valid_places
+stories = @community.stories.preload(:places).where(permission_level: :anonymous)
 json.storiesCount stories.size
 json.points stories.flat_map(&:public_points).uniq
 

--- a/rails/app/views/home/_home.json.jbuilder
+++ b/rails/app/views/home/_home.json.jbuilder
@@ -1,4 +1,4 @@
-json.stories stories do |story|
+json.stories stories.with_valid_places do |story|
   json.extract! story, :title, :desc, :id, :created_at
   json.points story.places.map(&:point_geojson)
   json.places story.places

--- a/rails/app/views/home/_home.json.jbuilder
+++ b/rails/app/views/home/_home.json.jbuilder
@@ -1,4 +1,4 @@
-json.stories stories.with_valid_places do |story|
+json.stories stories do |story|
   json.extract! story, :title, :desc, :id, :created_at
   json.points story.places.map(&:point_geojson)
   json.places story.places


### PR DESCRIPTION
This PR adds a scope to the Place and Story Models to filter out any places that have null coordinates (primarily for the front end of TS Main and Explore).

Although we are currently requiring lat/long fields when creating a new Place in the CMS, the Importer currently permits the user to upload Places without lat/longs, hence introducing a bug where Places without lat/long are passed on to React.

We are now adding the stories associated with the communities when they are fetched, not when they are filtered.

In the future we need to rework the Importer as a whole, but that's a whole 'nother epic.