### PR TITLE
Remove leading/trailing whitespace for imported has_many fields

### DIFF
--- a/documentation/DEVELOPMENT.md
+++ b/documentation/DEVELOPMENT.md
@@ -33,22 +33,22 @@ If you are working in an internet-connected environment, you will need to add a 
 
 ### ESLint
 
-We use ESLint with Airbnb community style-guide for linting JavaScript and JSX for files under app/javascript.
+We use ESLint with Airbnb community style-guide for linting JavaScript and JSX for files in `rails/app/javascript`.
 
-Please check [ESLint editor-integrations page](https://eslint.org/docs/user-guide/integrations#editors) to read about how to integrate ESLint with your IDE/editor
+Please check [ESLint editor-integrations page](https://eslint.org/docs/user-guide/integrations#editors) to read about how to integrate ESLint with your IDE/editor.
 
 ### Tests
 
 You can run RSpec tests with
 
 ```
-    docker-compose exec web rspec
+    docker compose exec web rspec
 ```
 
 We also support Javascript unit testing, with Enzyme for snapshots.
 
 ```
-    docker-compose exec web yarn test
+    docker compose exec web yarn test
 ```
 
 ## Backup and restore the Terrastories database

--- a/documentation/DEVELOPMENT.md
+++ b/documentation/DEVELOPMENT.md
@@ -33,22 +33,22 @@ If you are working in an internet-connected environment, you will need to add a 
 
 ### ESLint
 
-We use ESLint with Airbnb community style-guide for linting JavaScript and JSX for files in `rails/app/javascript`.
+We use ESLint with Airbnb community style-guide for linting JavaScript and JSX for files under app/javascript.
 
-Please check [ESLint editor-integrations page](https://eslint.org/docs/user-guide/integrations#editors) to read about how to integrate ESLint with your IDE/editor.
+Please check [ESLint editor-integrations page](https://eslint.org/docs/user-guide/integrations#editors) to read about how to integrate ESLint with your IDE/editor
 
 ### Tests
 
 You can run RSpec tests with
 
 ```
-    docker compose exec web rspec
+    docker-compose exec web rspec
 ```
 
 We also support Javascript unit testing, with Enzyme for snapshots.
 
 ```
-    docker compose exec web yarn test
+    docker-compose exec web yarn test
 ```
 
 ## Backup and restore the Terrastories database

--- a/rails/app/models/concerns/importable.rb
+++ b/rails/app/models/concerns/importable.rb
@@ -120,7 +120,7 @@ module Importable
 
         # Find or create has_many* relationships
         @klass.associated_attribute_names.each do |association|
-          values = attributes[association].to_s.split(",")
+          values = attributes[association].to_s.split(",").map(&:strip)
           attributes[association] = values.map do |name|
             association.to_s.singularize.classify.constantize.find_or_create_by(name: name, community_id: @community_id)
           end

--- a/rails/app/models/concerns/importable.rb
+++ b/rails/app/models/concerns/importable.rb
@@ -120,9 +120,9 @@ module Importable
 
         # Find or create has_many* relationships
         @klass.associated_attribute_names.each do |association|
-          values = attributes[association].to_s.split(",").map(&:strip)
+          values = attributes[association].to_s.split(",")
           attributes[association] = values.map do |name|
-            association.to_s.singularize.classify.constantize.find_or_create_by(name: name, community_id: @community_id)
+            association.to_s.singularize.classify.constantize.find_or_create_by(name: name.strip, community_id: @community_id)
           end
         end
 

--- a/rails/spec/fixtures/files/story_with_trailing_whitespaces.csv
+++ b/rails/spec/fixtures/files/story_with_trailing_whitespaces.csv
@@ -1,0 +1,4 @@
+name,description,speakers,places,interview_location,date_interviewed,interviewer,language,media,permission_level
+Journey to the Mountains,An exciting tale of a hiking adventure in the Rockies.,"John Doe, Maria Rossi, Hiroshi Nakamura","Rocky Mountains, Colorado",Denver Studio,2023-09-25,Alice Smith,English,video1.mp4,Admin
+Life in Venice,A deep dive into the daily life of Venetians.,Maria Rossi,"Venice, Tokyo",Venice Canal,2023-06-15,Bob Brown,Italian,video2.mp4,
+Exploring Tokyo's Cuisine,A foodie's journey through Tokyo's best eateries.,"Hiroshi Nakamura, John Doe","Tokyo, Rocky Mountains, Venice Canal",Tokyo Tower,2023-07-20,Catherine White,Japanese,video3.mp4,

--- a/rails/spec/models/story_spec.rb
+++ b/rails/spec/models/story_spec.rb
@@ -104,6 +104,16 @@ RSpec.describe Story, type: :model do
       end
     end
 
+    context "when has_many associations have trailing whitespaces" do
+      it "strips trailing whitespaces from Speaker_name and Place_name" do
+        described_class.import(file_fixture('story_with_trailing_whitespaces.csv'), community.id, mapped_headers)
+        story = described_class.last
+  
+        expect(story.speakers.map(&:name)).to all(satisfy { |name| name == name.strip })
+        expect(story.places.map(&:name)).to all(satisfy { |name| name == name.strip })
+      end
+    end
+
     context "with media attachments" do
       before do
         stub_const("Importable::IMPORT_PATH", "spec/fixtures/media/")


### PR DESCRIPTION
This PR solves a pain point that a number of users are currently having with the importer, having to do with leading whitespaces in the `stories` and `places` fields for Speaker CSV import, which are used to set up a has_many relationship with rows in the Story and Place models (find or create).

These users are trying to import CSVs that have spaces between the values:

![image](https://github.com/Terrastories/terrastories/assets/31662219/52b1092d-ad67-41d8-ac0a-9d3022250e34)

Currently, the importer will split these up and create them as follows (note the leading whitespace):

```
# => ["Chris /"Kelisi/" Flink", " Frederick /"oom Bree/" Valentijn"]
# => ["Kwango", " Bakaafeti", " Kogondia", " Shatumaipa"]
```

This results in the importer creating duplicate places ` Bakaafeti`, ` Kogondia`, ` Shatumaipa`, and duplicate speaker ` Frederick "oom Bree" Valentijn` because they are distinct from the places / speakers that already exist, but without the leading whitespace. (They are not actually dupes of course because the string is unique, but they appear that way to the user.)

I think for most of our users, it makes sense to have a space for legibility purposes (or whatever tools they are using to format their CSVs end up inserting one). Rather than forcing them to remove all spaces before importing, I think it's good to implement this fix to strip all leading/trailing whitespaces for these fields. (I think it's not as much of an issue for the other fields that don't explicitly set up a relationship with rows from another model.)

(I _think_ the pre-2022 refactor importer also removed trailing/leading whitespaces, so some long-time users are finding that their CSVs which used to work are now having this issue.)

I tested this out with a Stories CSV that was creating >50 "duplicate" places and ~15 "duplicate" stories; this fix ensured all of them were correctly setting up has_many relationships with the existing whitespace-free places / stories that were already imported.