### PR TITLE
fix: on React, load marker images before adding layers

### DIFF
--- a/rails/app/javascript/components/Map.jsx
+++ b/rails/app/javascript/components/Map.jsx
@@ -49,63 +49,23 @@ export default class Map extends Component {
     });
 
     this.map.on("load", () => {
-
-      // Add map point data to the map
-      this.addMapPoints();
-
-      // Add mapbox markers to the map
-      this.map.addLayer({
-        id: STORY_POINTS_LAYER_ID,
-        source: STORY_POINTS_DATA_SOURCE,
-        filter: ['!', ['has', 'point_count']], // single point, non-cluster
-        type: "symbol",
-        layout: {
-          "icon-image": "ts-marker",
-          "icon-padding": 0,
-          "icon-allow-overlap": true,
-          "icon-size": 0.75
+      // Load map marker images before adding layers
+      this.map.loadImage(this.props.markerImgUrl, (error, image) => {
+        if (error) throw "Error loading marker images: " + error;
+        if (!this.map.hasImage('ts-marker')) {
+            this.map.addImage('ts-marker', image);
         }
-      });
 
-      // Add clusters for overlapping markers
-      this.map.addLayer({
-        id: 'clusters',
-        source: STORY_POINTS_DATA_SOURCE,
-        filter: ['has', 'point_count'], // multiple points, cluster
-        type: "symbol",
-        layout: {
-          "icon-image": "ts-marker-cluster",
-          "icon-padding": 0,
-          "icon-allow-overlap": true,
-          "icon-size": [ // make cluster size reflect number of points within
-              "interpolate",
-              ["linear"],
-              ['get', 'point_count'],
-              // when number of points in cluster is 2, size will be 0.7 * single point
-              2,
-              0.7,
-              // when number of points in cluster is 10 or more, size will be 0.8 * single point
-              10,
-              0.8
-          ]
-        }
-      });
+        this.map.loadImage(this.props.markerClusterImgUrl, (error, image) => {
+            if (error) throw "Error loading marker images: " + error;
+            if (!this.map.hasImage('ts-marker-cluster')) {
+                this.map.addImage('ts-marker-cluster', image);
+            }
 
-      // Add labels for number of points clustered for overlapping markers
-      this.map.addLayer({
-        id: 'clustercount',
-        source: STORY_POINTS_DATA_SOURCE,
-        filter: ['has', 'point_count'], // multiple points, cluster
-        type: "symbol",
-        layout: {
-          'text-field': '{point_count_abbreviated}',
-          'text-font': ['Open Sans Bold'],
-          'text-size': 16,
-          'text-offset': [0.2, 0.1]
-          },
-        paint: {
-          'text-color': "#ffffff",
-        }
+            // After images are loaded, add your data and layers:
+            this.addMapPoints();
+            this.addPlaceMarkerLayers();
+        });
       });
 
       // Add 3d terrain DEM layer if activated
@@ -229,15 +189,62 @@ export default class Map extends Component {
       clusterMaxZoom: 14, // max zoom on which to cluster points, default is 14
       clusterRadius: 50 // radius of each cluster when clustering points, default is 50
     });
-    // default Terrastories marker icon
-    this.map.loadImage(this.props.markerImgUrl, (error, image) => {
-      if (error) throw "Error loading marker images: " + error;
-      this.map.addImage('ts-marker', image);
+  }
+
+  addPlaceMarkerLayers() {
+    // Add mapbox markers to the map
+    this.map.addLayer({
+      id: STORY_POINTS_LAYER_ID,
+      source: STORY_POINTS_DATA_SOURCE,
+      filter: ['!', ['has', 'point_count']], // single point, non-cluster
+      type: "symbol",
+      layout: {
+        "icon-image": "ts-marker",
+        "icon-padding": 0,
+        "icon-allow-overlap": true,
+        "icon-size": 0.75
+      }
     });
-    // default Terrastories cluster icon; in the future we will need to think of way to visualize clusters of user-submitted custom icons
-    this.map.loadImage(this.props.markerClusterImgUrl, (error, image) => {
-      if (error) throw "Error loading marker images: " + error;
-      this.map.addImage('ts-marker-cluster', image);
+
+    // Add clusters for overlapping markers
+    this.map.addLayer({
+      id: 'clusters',
+      source: STORY_POINTS_DATA_SOURCE,
+      filter: ['has', 'point_count'], // multiple points, cluster
+      type: "symbol",
+      layout: {
+        "icon-image": "ts-marker-cluster",
+        "icon-padding": 0,
+        "icon-allow-overlap": true,
+        "icon-size": [ // make cluster size reflect number of points within
+            "interpolate",
+            ["linear"],
+            ['get', 'point_count'],
+            // when number of points in cluster is 2, size will be 0.7 * single point
+            2,
+            0.7,
+            // when number of points in cluster is 10 or more, size will be 0.8 * single point
+            10,
+            0.8
+        ]
+      }
+    });
+
+    // Add labels for number of points clustered for overlapping markers
+    this.map.addLayer({
+      id: 'clustercount',
+      source: STORY_POINTS_DATA_SOURCE,
+      filter: ['has', 'point_count'], // multiple points, cluster
+      type: "symbol",
+      layout: {
+        'text-field': '{point_count_abbreviated}',
+        'text-font': ['Open Sans Bold'],
+        'text-size': 16,
+        'text-offset': [0.2, 0.1]
+        },
+      paint: {
+        'text-color': "#ffffff",
+      }
     });
   }
 


### PR DESCRIPTION
Resolves #965.

In the Map component, this PR refactors the `this.map.on("load")` event to prioritize loading the marker images before adding the Terrastories point data and layers. This approach addresses a race condition where the layers might sometimes be added to the map before the marker images had fully loaded.

To improve code clarity, I've also extracted the layer addition logic into its own function, `addPlaceMarkerLayers()`.

Before:

![image](https://github.com/Terrastories/terrastories/assets/31662219/ea6b41b9-aadb-4fc7-994a-cb312044fe1c)

After:
![image](https://github.com/Terrastories/terrastories/assets/31662219/5f2a52b5-7e10-482e-9b49-bcaa3a2ad635)


In so doing, the following warnings in the console have also gone away:
```
mapbox-gl.js:31 Image "ts-marker" could not be loaded. Please make sure you have added the image with map.addImage() or a "sprite" property in your style. You can provide missing images by listening for the "styleimagemissing" map event.
mapbox-gl.js:31 Image "ts-marker-cluster" could not be loaded. Please make sure you have added the image with map.addImage() or a "sprite" property in your style. You can provide missing images by listening for the "styleimagemissing" map event.
```