### PR TITLE
fix: use github context ref_name instead of ref

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -25,5 +25,5 @@ jobs:
         platforms: linux/amd64,linux/arm64,linux/arm/v7
         push: true
         tags: |
-          terrastories/terrastories:${{ github.ref }}
+          terrastories/terrastories:${{ github.ref_name }}
           terrastories/terrastories:latest


### PR DESCRIPTION
ref returns refs/tags/tag_name
ref_name returns the name itself