### PR TITLE
chore(offline): prep and make adjustments for a smoother offline experience

### DIFF
--- a/rails/Dockerfile
+++ b/rails/Dockerfile
@@ -57,9 +57,7 @@ EXPOSE 3000
 
 ENV RAILS_ENV="production" \
     AUTO_RUN_MIGRATIONS=on \
-    DATABASE_URL="" \
-    OFFLINE_MODE="no" \
-    SECRET_KEY_BASE=""
+    DATABASE_URL=""
 
 RUN apk --no-cache add \
     tzdata \

--- a/rails/config/environments/offline.rb
+++ b/rails/config/environments/offline.rb
@@ -31,7 +31,9 @@ Rails.application.configure do
   # including the ones that sign and encrypt cookies.
   config.secret_key_base = lambda {
     # Always use configured SECRET_KEY_BASE env var if one is configured
-    if ENV.fetch("SECRET_KEY_BASE", false)
+    # Presence check is to ensure that we don't attempt to set an empty string
+    # as the secret_key_base.
+    if ENV.fetch("SECRET_KEY_BASE", false).present?
       secrets.secret_key_base ||= ENV["SECRET_KEY_BASE"]
     else
       key_file = Rails.root.join("tmp/offline_secret.txt")
@@ -95,8 +97,6 @@ Rails.application.configure do
 
   # Compress CSS using a preproccessor
   # config.assets.css_compressor = :sass
-
-  config.assets.prefix = "/offline-assets"
 
   # Fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false


### PR DESCRIPTION
- Removed an unnecessary `OFFLINE_MODE` ENV in the prod Docker image. The default is always no, so listing it is not necessary.
- Removed `SECRET_KEY_BASE` from default ENV in the prod Docker image. It's a required ENV, but should be managed by the image user, rather than an empty default set that we don't update later.
- Removed asset-prefix in offline environment file: we don't compile assets using this environment, so we can share them with the default asset path.
- Added a presence check for offline mode. In the event that `SECRET_KEY_BASE` var exists, but is empty, we auto-generate one for them rather than throwing an error.