### PR TITLE
Add Explore Terrastories to documentation, and other clarifying fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,8 +9,10 @@
 # on servers without needing a code change.
 CORS_ORIGINS="localhost:1080,\Ahttps:\/\/[a-z0-9]{4}-[0-9]{2}-[0-9]{3}-[0-9]{3}-[0-9]{3}.ngrok.io\z"
 
-# If you are setting up your own online production instance, please reach out to
-# the Terrastories Stewards for help.
+# If you are setting up your own online production instance, please see this page
+# https://docs.terrastories.app/setting-up-a-terrastories-server/hosting-environments/hosting-terrastories-online
+# If you have any additional questions, reach out to the Terrastories Stewards team
+# for help.
 
 # ==> Default Online Mapbox Configuration
 # Mapbox access token and style are required to run Terrastories in an internet-
@@ -24,5 +26,7 @@ CORS_ORIGINS="localhost:1080,\Ahttps:\/\/[a-z0-9]{4}-[0-9]{2}-[0-9]{3}-[0-9]{3}-
 # DEFAULT_MAPBOX_TOKEN=pk.set-your-key-here
 
 # Configure a custom Mapbox style. This can be any off-the-shelf style provided
-# by Mapbox, or a custom style associated with your personal access token.
+# by Mapbox, or a custom style associated with your personal access token. This
+# default map style will be used by default across all onboarded communities to
+# this instance.
 # DEFAULT_MAP_STYLE=mapbox://styles/mapbox/streets-v11

--- a/README.md
+++ b/README.md
@@ -25,9 +25,11 @@
 
 Terrastories is a Dockerized Rails and React app that uses [**Mapbox GL JS**](https://mapbox.com) / [**MapLibre GL JS**](https://maplibre.com/) to help users locate place-based media content or narrative stories on an interactive map. As a local-first application, Terrastories is designed to work entirely offline, so that remote communities can access the application entirely without needing internet connectivity.
 
-The Terrastories interface is principally composed of an interactive map and a sidebar with media content. Users can explore the map and click on activated points to see the stories associated with those points. Alternatively, users can interact with the sidebar and click on stories to see where in the landscape these narratives took place. 
+The main Terrastories interface is principally composed of an interactive map and a sidebar with media content. Users can explore the map and click on activated points to see the stories associated with those points. Alternatively, users can interact with the sidebar and click on stories to see where in the landscape these narratives took place. 
 
 By means of a content management system, users with the right level of access can also explore, add, edit, remove, and import stories, or set them as restricted so that they are viewable only with a special login. Users can design and customize the content of the interactive map entirely.
+
+There is also [Explore Terrastories](https://github.com/terrastories/explore-terrastories), a separate React app that allows public exploration of unrestricted stories that communities have opted into sharing. Explore Terrastories queries the API of the main Terrastories application provided in this repository.
 
 Learn more about Terrastories on [our website](https://terrastories.app/). 
 

--- a/documentation/DEVELOPMENT.md
+++ b/documentation/DEVELOPMENT.md
@@ -5,14 +5,20 @@
 - [Developing with Terrastories](#developing-with-terrastories)
   - [Table of Contents](#table-of-contents)
   - [Setting up your Development Environment](#setting-up-your-development-environment)
+    - [Rails](#rails)
     - [ESLint](#eslint)
     - [Tests](#tests)
+  - [Working with Explore Terrastories](#working-with-explore-terrastories)
   - [Backup and restore the Terrastories database](#backup-and-restore-the-terrastories-database)
   - [Running Terrastories in Offline Mode](#running-terrastories-in-offline-mode)
 
 ## Setting up your Development Environment
 
-Most developer contributions will be focused on the rails app. Because this project uses
+If you are working in an internet-connected environment, you will need to add a valid Mapbox access token to your `.env` file in order for the Terrastories map to work (whether it is in the `dev` or `offline` profile). Alternatively, you may add an access token (and Mapbox map style) for a community via the Themes dashboard in the administrative menu, to get a map to work for that specific community only.
+
+### Rails
+
+Many developer contributions will be focused on the rails app. Because this project uses
 docker, we already have a uniform ruby/rails development environment in our rails docker
 image. Any time you need to run a rails command you should do so from a running docker
 container to take advantage of this consistent environment. Use the following command to
@@ -29,8 +35,6 @@ environment. Always use the rails container instead.**
 Any changes to source files should be made directly in your local filesystem under the
 `/opt/terrastories` directory using your preferred editing tools.
 
-If you are working in an internet-connected environment, you will need to add a valid Mapbox access token to your `.env` file in order for the Terrastories map to work (whether it is in the `dev` or `offline` profile). Alternatively, you may add an access token (and Mapbox map style) for a community via the Themes dashboard in the administrative menu, to get a map to work for that specific community only.
-
 ### ESLint
 
 We use ESLint with Airbnb community style-guide for linting JavaScript and JSX for files in `rails/app/javascript`.
@@ -38,6 +42,8 @@ We use ESLint with Airbnb community style-guide for linting JavaScript and JSX f
 Please check [ESLint editor-integrations page](https://eslint.org/docs/user-guide/integrations#editors) to read about how to integrate ESLint with your IDE/editor.
 
 ### Tests
+
+Terrastories uses RSpec for testing and we try to have unit tests for as many components of the application as possible. 
 
 You can run RSpec tests in the Docker `web` container. There are different ways to do this.
 
@@ -61,6 +67,13 @@ We also support Javascript unit testing, with Enzyme for snapshots.
 docker compose exec web yarn test
 ```
 
+## Working with Explore Terrastories
+
+Explore Terrastories is a React application that provides an opt-in view of unrestricted stories for public exploration. It is a different application and server from what is deployed in this repository. 
+
+More specific instructions on working with Explore Terrastories can be found [in the repo](https://github.com/terrastories/explore-terrastories), but it is important to know that Explore Terrastories works by accessing an API orchestrated by the controllers in `/controllers/api/` and with responses provided through JBuilder. 
+
+Access to the API is controlled through CORS via an env var `CORS_ORIGINS` that should specify the address of your Explore Terrastories server in the `.env` file.
 ## Backup and restore the Terrastories database
 
 Terrastories stores Places, Speakers, and Stories in a database (Postgres DB). it is possible to back these data up and restore them by running lines of code in a bash terminal.
@@ -78,25 +91,12 @@ docker volume rm terrastories_postgres_data
 docker run --rm -i -v "terrastories_postgres_data:/pgdata" busybox tar -xvzf - -C /pgdata <db-backup.tgz
 ```
 
-Or using Powershell (Windows):
 
-Backup the DB in PS with:
-
-```
-docker run --rm -v "terrastories_postgres_data:/pgdata" -v "$(pwd):/host" busybox tar -cvzf /host/db-backup-test.tgz -C /pgdata .
-```
-
-Restore a backup in PS with:
-
-```
-docker run --rm -i -v "terrastories_postgres_data:/pgdata" -v "$(pwd):/source/" busybox tar -xvzf /source/db-backup.tgz -C /pgdata
-```
-
-Note: the above code is assuming your build is called `terrastories`. It may be necessary to run `docker volume ls` to get the right Docker container name ending with `_postgres_data`.
+Note: the above code is assuming your build is called `terrastories`. If it is not, it may be necessary to run `docker volume ls` to get the right Docker container name ending with `_postgres_data`.
 
 ## Running Terrastories in Offline Mode
 
-Terrastories offline mode is generally used in the field, when there is no access to the internet.
+Terrastories offline mode is generally used in the field, when there is no access to the internet. It is a heavily cached production build that should not be used for direct development work. You can switch to the `offline` profile to test changes made in the `dev` profile if you are working on features that should be tested in both environments, however.
 
 To start Terrastories with the offline profile, run
 


### PR DESCRIPTION
This PR adds information and instructions on how to work with Explore Terrastories. There are also some small clarifying fixes about tests, env vars, working with the offline profile, and some minor copy editing.