### PR TITLE
feature(explore): media preview

### DIFF
--- a/rails/Dockerfile
+++ b/rails/Dockerfile
@@ -26,7 +26,8 @@ RUN apk --no-cache add --update \
     libxslt-dev \
     libc6-compat \
     imagemagick \
-    ffmpeg && \
+    ffmpeg \
+    poppler && \
     gem update --system --no-document && \
     gem install bundler --no-document --force
 
@@ -68,7 +69,8 @@ RUN apk --no-cache add \
     libxslt \
     libc6-compat \
     imagemagick \
-    ffmpeg && \
+    ffmpeg \
+    poppler && \
     gem update --system --no-document && \
     gem install bundler --no-document --force
 

--- a/rails/app/models/media.rb
+++ b/rails/app/models/media.rb
@@ -24,7 +24,7 @@ class Media < ApplicationRecord
     ],
     size: { less_than_or_equal_to: 200.megabytes }
 
-  delegate :content_type, :blob_id, :blob, to: :media
+  delegate :content_type, :blob_id, :blob, :representable?, to: :media
 end
 
 # == Schema Information

--- a/rails/app/models/story.rb
+++ b/rails/app/models/story.rb
@@ -26,6 +26,16 @@ class Story < ApplicationRecord
     end.uniq
   end
 
+  def media_preview_thumbnail
+    previewable_media = media.find { |m| m.representable? }
+
+    return unless previewable_media
+
+    Rails.application.routes.url_helpers.rails_representation_url(
+      previewable_media.media.representation(resize_to_limit: [200, 200]).processed
+    )
+  end
+
   def self.export_sample_csv
     headers = %w{name description speakers places interview_location date_interviewed interviewer language media permission_level }
 

--- a/rails/app/views/api/stories/index.json.jbuilder
+++ b/rails/app/views/api/stories/index.json.jbuilder
@@ -3,6 +3,7 @@ json.points @stories.flat_map { |s| s.public_points }.uniq
 json.stories @stories do |story|
   json.extract! story, :id, :title, :topic, :desc, :language
   json.mediaContentTypes story.media_types
+  json.mediaPreviewUrl story.media_preview_thumbnail
 
   json.createdAt story.created_at
   json.updatedAt story.updated_at


### PR DESCRIPTION
In an effort to streamline the Explore story list view, we want to provide a preview image of a representable media to show that there is media to explore in an expanded view.

This adds the first findable representable media, generates the preview/representation, and then returns the processed URL through the API endpoint.