### PR TITLE
fix(API): Catastrophic 500 when media cannot be processed

### DIFF
--- a/rails/app/models/media.rb
+++ b/rails/app/models/media.rb
@@ -24,7 +24,7 @@ class Media < ApplicationRecord
     ],
     size: { less_than_or_equal_to: 200.megabytes }
 
-  delegate :content_type, :blob_id, :blob, :representable?, to: :media
+  delegate :attach, :content_type, :blob_id, :blob, :representable?, to: :media
 end
 
 # == Schema Information

--- a/rails/app/models/story.rb
+++ b/rails/app/models/story.rb
@@ -34,6 +34,8 @@ class Story < ApplicationRecord
     Rails.application.routes.url_helpers.rails_representation_url(
       previewable_media.media.representation(resize_to_limit: [200, 200]).processed
     )
+  rescue ActiveStorage::Error
+    nil
   end
 
   def self.export_sample_csv

--- a/rails/spec/factories/media_factory.rb
+++ b/rails/spec/factories/media_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :media do
+    story
+    media { Rack::Test::UploadedFile.new('spec/fixtures/media/terrastories.png', 'image/png') }
+  end
+end

--- a/rails/spec/models/story_spec.rb
+++ b/rails/spec/models/story_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe Story, type: :model do
       it "strips trailing whitespaces from Speaker_name and Place_name" do
         described_class.import(file_fixture('story_with_trailing_whitespaces.csv'), community.id, mapped_headers)
         story = described_class.last
-  
+
         expect(story.speakers.map(&:name)).to all(satisfy { |name| name == name.strip })
         expect(story.places.map(&:name)).to all(satisfy { |name| name == name.strip })
       end
@@ -240,6 +240,28 @@ RSpec.describe Story, type: :model do
   describe 'export_sample_csv' do
     it 'downloads a csv' do
       expect(described_class.export_sample_csv).to eq("name,description,speakers,places,interview_location,date_interviewed,interviewer,language,media,permission_level\n")
+    end
+  end
+
+  describe '#media_preview_thumbnail' do
+    let(:story) { create(:story, :with_places, :with_speakers) }
+
+    it 'returns nil when story has no previewable media' do
+      expect(story.media_preview_thumbnail).to be_nil
+    end
+
+    it 'returns processed URL for media' do
+      media = create(:media, story: story)
+
+      expect(story.media_preview_thumbnail).to match(/^http(.*)\/terrastories.png$/)
+    end
+
+    it 'returns nil if media processing throws an error' do
+      create(:media, story: story)
+
+      expect_any_instance_of(ActiveStorage::Variant).to receive(:processed).and_raise(ActiveStorage::InvariableError)
+
+      expect(story.media_preview_thumbnail).to be_nil
     end
   end
 end


### PR DESCRIPTION
This fixes an issue with the Explore API where when a Community Map is loaded stories are requested, the Story sidebar hangs forever. After looking into it, we noticed there was a catastrophic error on the backend from ffmpeg trying to process media that couldn't actually be processed.

Adds red spec for showing the error and code to make that spec green.

The documentation on `representation(opts).processed` suggested that checking `representable?` would ensure we don't attempt to process media that can't be variable or previewable. It appears that we needed additional guards when processing the preview or variant, as these can fail despite the processor accepting the blob. Since the current solution is to catch all errors originating from Active Storage, we only included one spec for one of the possible errors.