### PR TITLE
fix: Speaker birthplace not persisted

### DIFF
--- a/rails/app/controllers/dashboard/speakers_controller.rb
+++ b/rails/app/controllers/dashboard/speakers_controller.rb
@@ -75,7 +75,7 @@ module Dashboard
         :photo,
         :speaker_community,
         :birthdate,
-        :birthplace,
+        :birthplace_id,
         story_ids: []
       )
     end

--- a/rails/app/views/dashboard/speakers/_form.html.erb
+++ b/rails/app/views/dashboard/speakers/_form.html.erb
@@ -14,7 +14,7 @@
   <%= f.date_field :birthdate %>
 
   <%= f.label :birthplace_id %>
-  <%= f.collection_select :birthplace_id, current_community.places, :id, :name %>
+  <%= f.collection_select :birthplace_id, current_community.places, :id, :name, include_blank: true %>
 
   <%= f.label :story_ids %>
   <div class="checklist">


### PR DESCRIPTION
When creating or updating a Speaker, the birthplace is not persisted when changed.

This fix ensures that birthplace, when selected, is persisted to the db.

THis also updates the dropdown to allow a blank value (as birthplace is optional).