### PR TITLE
Make running tests easier

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -3,6 +3,7 @@ services:
     profiles:
       - offline
       - dev
+      - test
     image: postgres:11
     restart: unless-stopped
     ports:
@@ -34,6 +35,24 @@ services:
       - ./rails:/api
       - ./data/media:/media
       - ./data/import/media:/api/import/media
+
+  test:
+    profiles: [test]
+    image: terrastories/devcore:latest
+    entrypoint: ["bundle", "exec", "rspec"]
+    restart: no
+    stdin_open: true
+    tty: true
+    depends_on:
+      - db
+    environment:
+      - RAILS_ENV=test
+    volumes:
+      - bundler:/usr/local/bundle
+      - ./rails:/api
+      - ./data/media:/media
+      - ./data/import/media:/api/import/media
+      - ./map:/api/public/map:ro
 
   nginx-proxy:
     profiles:

--- a/documentation/DEVELOPMENT.md
+++ b/documentation/DEVELOPMENT.md
@@ -45,26 +45,14 @@ Please check [ESLint editor-integrations page](https://eslint.org/docs/user-guid
 
 Terrastories uses RSpec for testing and we try to have unit tests for as many components of the application as possible. 
 
-You can run RSpec tests in the Docker `web` container. There are different ways to do this.
-
-If you already have a container running:
-
 ```
-docker compose exec -e RAILS_ENV=test web bundle exec rspec
+docker compose run --rm test
 ```
 
-(You can also run `RAILS_ENV=test bundle exec rspec` in a running container shell if you prefer.)
-
-If you want to boot a separate container for tests, and then take it down:
+If you wish to run a specific test or test file, you may pass that as the first argument:
 
 ```
-docker compose run --rm -e RAILS_ENV=test web bundle exec rspec
-``` 
-
-We also support Javascript unit testing, with Enzyme for snapshots.
-
-```
-docker compose exec web yarn test
+docker compose run --rm test spec/path/to/my_spec.rb:line
 ```
 
 ## Working with Explore Terrastories


### PR DESCRIPTION
This creates a compose test service that adds the ability to easily run specs without needing to understand the intricacies of docker.

The service defines a special entry point so booting the service will automatically run specs. It also allows the standard spec command line interface to work, e.g. --flags and specific test files.