### PR TITLE
Fix GHA buildx file path

### DIFF
--- a/.github/workflows/on-merge-master.yml
+++ b/.github/workflows/on-merge-master.yml
@@ -24,7 +24,7 @@ jobs:
       uses: docker/build-push-action@v5
       with:
         context: .
-        file: "{{defaultContext}}/rails/Dockerfile"
+        file: ./rails/Dockerfile
         target: devcore
         platforms: linux/amd64,linux/arm64,linux/arm/v7
         push: true

--- a/.github/workflows/on-merge-master.yml
+++ b/.github/workflows/on-merge-master.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Build and push
       uses: docker/build-push-action@v5
       with:
-        context: .
+        context: "{{defaultContext}}"
         file: ./rails/Dockerfile
         target: devcore
         platforms: linux/amd64,linux/arm64,linux/arm/v7

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Build and push
       uses: docker/build-push-action@v5
       with:
-        context: .
+        context: "{{defaultContext}}"
         file: ./rails/Dockerfile
         platforms: linux/amd64,linux/arm64,linux/arm/v7
         push: true

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -22,7 +22,7 @@ jobs:
       uses: docker/build-push-action@v5
       with:
         context: .
-        file: "{{defaultContext}}/rails/Dockerfile"
+        file: ./rails/Dockerfile
         platforms: linux/amd64,linux/arm64,linux/arm/v7
         push: true
         tags: |

--- a/rails/Dockerfile
+++ b/rails/Dockerfile
@@ -28,7 +28,6 @@ RUN apk --no-cache add --update \
     imagemagick \
     ffmpeg \
     poppler && \
-    gem update --system --no-document && \
     gem install bundler --no-document --force -v '~> 2.4.7'
 
 WORKDIR /tmp


### PR DESCRIPTION
In #986, I added `workflow_dispatch` on the on-merge-master.yml workflow. This allows us to test changes on the GHA manually in the Actions area and target our testing branch.

The changes made in #985 inadvertently switched to the action/checkout syntax rather than the default GH context that the docker build action utilizes.