### PR TITLE
feat(api): Include protomaps config

### DIFF
--- a/rails/app/views/api/communities/index.json.jbuilder
+++ b/rails/app/views/api/communities/index.json.jbuilder
@@ -9,7 +9,8 @@ envelope(json) do
       json.displayImage rails_blob_url(community.display_image)
     end
 
-    if community.theme.static_map.attached?
+    # only send static map image if mapbox is configured
+    if !community.theme.use_maplibre? && community.theme.static_map.attached?
       json.staticMapUrl rails_blob_url(community.theme.static_map)
     end
 
@@ -18,6 +19,9 @@ envelope(json) do
       json.mapboxStyle community.theme.mapbox_style
       json.mapbox3dEnabled community.theme.mapbox_3d
       json.mapProjection community.theme.map_projection
+
+      json.pmApiKey community.theme.protomaps_api_key
+      json.pmBasemapStyle community.theme.basemap_style
 
       json.center community.theme.center
 

--- a/rails/app/views/api/communities/show.json.jbuilder
+++ b/rails/app/views/api/communities/show.json.jbuilder
@@ -30,6 +30,9 @@ envelope(json) do
     json.mapbox3dEnabled @community.theme.mapbox_3d
     json.mapProjection @community.theme.map_projection
 
+    json.pmApiKey @community.theme.protomaps_api_key
+    json.pmBasemapStyle @community.theme.basemap_style
+
     json.centerLat @community.theme.center_lat
     json.centerLong @community.theme.center_long
     json.swBoundaryLat @community.theme.sw_boundary_lat

--- a/rails/spec/requests/api/public_community_spec.rb
+++ b/rails/spec/requests/api/public_community_spec.rb
@@ -51,6 +51,8 @@ RSpec.describe "Public Community (show) Endpoint", type: :request do
         "mapboxStyle",
         "mapbox3dEnabled",
         "mapProjection",
+        "pmApiKey",
+        "pmBasemapStyle",
         "centerLat",
         "centerLong",
         "swBoundaryLat",

--- a/rails/spec/support/active_storage.rb
+++ b/rails/spec/support/active_storage.rb
@@ -3,3 +3,7 @@ RSpec.configure do |config|
     FileUtils.rm_rf(ActiveStorage::Blob.service.root)
   end
 end
+
+def blob_url(blob, host = "www.example.com")
+  Rails.application.routes.url_helpers.rails_blob_url(blob, host: host)
+end


### PR DESCRIPTION
This adds the protomaps API key (when available) and the configured basemaps style name to the Public Community endpoints for the Explore interface to consume and use when available.